### PR TITLE
After CreateOrPatchUnstructuredObject obj is always populated

### DIFF
--- a/pkg/realizer/component.go
+++ b/pkg/realizer/component.go
@@ -71,7 +71,7 @@ func (r *componentRealizer) Do(component *v1alpha1.SupplyChainComponent, supplyC
 		}
 	}
 
-	err = r.repo.CreateOrPatchUnstructuredObject(stampedObject)
+	err = r.repo.AssureObjectExistsOnCluster(stampedObject)
 	if err != nil {
 		return nil, ApplyStampedObjectError{
 			Err:           err,

--- a/pkg/realizer/component_test.go
+++ b/pkg/realizer/component_test.go
@@ -238,7 +238,7 @@ var _ = Describe("Component", func() {
 			})
 		})
 
-		When("unable to CreateOrPatchUnstructuredObject the stamped object", func() {
+		When("unable to AssureObjectExistsOnCluster the stamped object", func() {
 			BeforeEach(func() {
 				component.Sources = []v1alpha1.ComponentReference{
 					{

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -17,6 +17,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	api_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -65,6 +66,11 @@ func (r *repository) CreateOrPatchUnstructuredObject(obj *unstructured.Unstructu
 		return err
 	} else if r.rc.UnchangedSinceCached(submitted, existingUnstructured) {
 		r.rc.Refresh(submitted)
+
+		objVal := reflect.ValueOf(obj)
+		existingVal := reflect.ValueOf(existingUnstructured)
+		reflect.Indirect(objVal).Set(reflect.Indirect(existingVal))
+
 		return nil
 	} else {
 		createOrPatchErr = r.patchUnstructured(existingUnstructured, obj)

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Repository", func() {
 			repo = repository.NewRepository(cl, cache)
 		})
 
-		Context("CreateOrPatchUnstructuredObject", func() {
+		Context("AssureObjectExistsOnCluster", func() {
 			var stampedObj *unstructured.Unstructured
 
 			BeforeEach(func() {
@@ -107,7 +107,7 @@ spec:
 			})
 
 			It("attempts to get the object from the apiServer", func() {
-				Expect(repo.CreateOrPatchUnstructuredObject(stampedObj)).To(Succeed())
+				Expect(repo.AssureObjectExistsOnCluster(stampedObj)).To(Succeed())
 
 				Expect(cl.GetCallCount()).To(Equal(1))
 
@@ -127,18 +127,18 @@ spec:
 				})
 
 				It("returns a helpful error", func() {
-					err := repo.CreateOrPatchUnstructuredObject(stampedObj)
+					err := repo.AssureObjectExistsOnCluster(stampedObj)
 					Expect(err).To(MatchError(ContainSubstring("get: some-error")))
 				})
 
 				It("does not create or patch any objects", func() {
-					_ = repo.CreateOrPatchUnstructuredObject(stampedObj)
+					_ = repo.AssureObjectExistsOnCluster(stampedObj)
 					Expect(cl.CreateCallCount()).To(Equal(0))
 					Expect(cl.PatchCallCount()).To(Equal(0))
 				})
 
 				It("does not write to the submitted or persisted cache", func() {
-					_ = repo.CreateOrPatchUnstructuredObject(stampedObj)
+					_ = repo.AssureObjectExistsOnCluster(stampedObj)
 					Expect(cache.SetCallCount()).To(Equal(0))
 				})
 			})
@@ -153,7 +153,7 @@ spec:
 				})
 
 				It("attempts to create the object", func() {
-					Expect(repo.CreateOrPatchUnstructuredObject(stampedObj)).To(Succeed())
+					Expect(repo.AssureObjectExistsOnCluster(stampedObj)).To(Succeed())
 
 					Expect(cl.CreateCallCount()).To(Equal(1))
 					_, createCallObj, _ := cl.CreateArgsForCall(0)
@@ -166,12 +166,12 @@ spec:
 					})
 
 					It("returns a helpful error", func() {
-						err := repo.CreateOrPatchUnstructuredObject(stampedObj)
+						err := repo.AssureObjectExistsOnCluster(stampedObj)
 						Expect(err).To(MatchError(ContainSubstring("create: some-error")))
 					})
 
 					It("does not write to the submitted or persisted cache", func() {
-						_ = repo.CreateOrPatchUnstructuredObject(stampedObj)
+						_ = repo.AssureObjectExistsOnCluster(stampedObj)
 						Expect(cache.SetCallCount()).To(Equal(0))
 					})
 				})
@@ -191,13 +191,13 @@ spec:
 					})
 
 					It("does not return an error", func() {
-						Expect(repo.CreateOrPatchUnstructuredObject(stampedObj)).To(Succeed())
+						Expect(repo.AssureObjectExistsOnCluster(stampedObj)).To(Succeed())
 					})
 
 					It("caches the submitted and persisted objects, as the persisted one may be modified by mutating webhooks", func() {
 						originalStampedObj := stampedObj.DeepCopy()
 
-						Expect(repo.CreateOrPatchUnstructuredObject(stampedObj)).To(Succeed())
+						Expect(repo.AssureObjectExistsOnCluster(stampedObj)).To(Succeed())
 						Expect(cache.SetCallCount()).To(Equal(1))
 						submitted, persisted := cache.SetArgsForCall(0)
 						Expect(*submitted).To(Equal(*originalStampedObj))
@@ -222,7 +222,7 @@ spec:
 				})
 
 				It("the cache is consulted to see if there was a change since the last time the cache was updated", func() {
-					Expect(repo.CreateOrPatchUnstructuredObject(stampedObj)).To(Succeed())
+					Expect(repo.AssureObjectExistsOnCluster(stampedObj)).To(Succeed())
 					Expect(cache.UnchangedSinceCachedCallCount()).To(Equal(1))
 
 					submitted, persisted := cache.UnchangedSinceCachedArgsForCall(0)
@@ -236,20 +236,20 @@ spec:
 					})
 
 					It("does not create or patch any objects", func() {
-						Expect(repo.CreateOrPatchUnstructuredObject(stampedObj)).To(Succeed())
+						Expect(repo.AssureObjectExistsOnCluster(stampedObj)).To(Succeed())
 						Expect(cl.CreateCallCount()).To(Equal(0))
 						Expect(cl.PatchCallCount()).To(Equal(0))
 					})
 
 					It("does not write to the submitted or persisted cache", func() {
-						Expect(repo.CreateOrPatchUnstructuredObject(stampedObj)).To(Succeed())
+						Expect(repo.AssureObjectExistsOnCluster(stampedObj)).To(Succeed())
 						Expect(cache.SetCallCount()).To(Equal(0))
 					})
 
 					It("refreshes the cache entry", func() {
 						originalStampedObj := stampedObj.DeepCopy()
 
-						Expect(repo.CreateOrPatchUnstructuredObject(stampedObj)).To(Succeed())
+						Expect(repo.AssureObjectExistsOnCluster(stampedObj)).To(Succeed())
 						Expect(cache.RefreshCallCount()).To(Equal(1))
 						Expect(cache.RefreshArgsForCall(0)).To(Equal(originalStampedObj))
 					})
@@ -257,7 +257,7 @@ spec:
 					It("populates the object passed into the function with the object in apiServer", func() {
 						originalStampedObj := stampedObj.DeepCopy()
 
-						_ = repo.CreateOrPatchUnstructuredObject(stampedObj)
+						_ = repo.AssureObjectExistsOnCluster(stampedObj)
 
 						Expect(stampedObj).To(Equal(existingObj))
 						Expect(stampedObj).NotTo(Equal(originalStampedObj))
@@ -270,7 +270,7 @@ spec:
 					})
 
 					It("patches the object", func() {
-						Expect(repo.CreateOrPatchUnstructuredObject(stampedObj)).To(Succeed())
+						Expect(repo.AssureObjectExistsOnCluster(stampedObj)).To(Succeed())
 						Expect(cl.PatchCallCount()).To(Equal(1))
 					})
 
@@ -290,13 +290,13 @@ spec:
 						})
 
 						It("does not return an error", func() {
-							Expect(repo.CreateOrPatchUnstructuredObject(stampedObj)).To(Succeed())
+							Expect(repo.AssureObjectExistsOnCluster(stampedObj)).To(Succeed())
 						})
 
 						It("caches the submitted and persisted objects, as the persisted one may be modified by mutating webhooks", func() {
 							originalStampedObj := stampedObj.DeepCopy()
 
-							Expect(repo.CreateOrPatchUnstructuredObject(stampedObj)).To(Succeed())
+							Expect(repo.AssureObjectExistsOnCluster(stampedObj)).To(Succeed())
 							Expect(cache.SetCallCount()).To(Equal(1))
 							submitted, persisted := cache.SetArgsForCall(0)
 							Expect(*submitted).To(Equal(*originalStampedObj))
@@ -309,12 +309,12 @@ spec:
 							cl.PatchReturns(errors.New("some-error"))
 						})
 						It("returns a helpful error", func() {
-							err := repo.CreateOrPatchUnstructuredObject(stampedObj)
+							err := repo.AssureObjectExistsOnCluster(stampedObj)
 							Expect(err).To(MatchError(ContainSubstring("patch: some-error")))
 						})
 
 						It("does not write to the submitted or persisted cache", func() {
-							_ = repo.CreateOrPatchUnstructuredObject(stampedObj)
+							_ = repo.AssureObjectExistsOnCluster(stampedObj)
 							Expect(cache.SetCallCount()).To(Equal(0))
 						})
 					})

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -247,9 +247,20 @@ spec:
 					})
 
 					It("refreshes the cache entry", func() {
+						originalStampedObj := stampedObj.DeepCopy()
+
 						Expect(repo.CreateOrPatchUnstructuredObject(stampedObj)).To(Succeed())
 						Expect(cache.RefreshCallCount()).To(Equal(1))
-						Expect(cache.RefreshArgsForCall(0)).To(Equal(stampedObj))
+						Expect(cache.RefreshArgsForCall(0)).To(Equal(originalStampedObj))
+					})
+
+					It("populates the object passed into the function with the object in apiServer", func() {
+						originalStampedObj := stampedObj.DeepCopy()
+
+						_ = repo.CreateOrPatchUnstructuredObject(stampedObj)
+
+						Expect(stampedObj).To(Equal(existingObj))
+						Expect(stampedObj).NotTo(Equal(originalStampedObj))
 					})
 				})
 

--- a/pkg/repository/repositoryfakes/fake_repository.go
+++ b/pkg/repository/repositoryfakes/fake_repository.go
@@ -102,7 +102,7 @@ type FakeRepository struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeRepository) CreateOrPatchUnstructuredObject(arg1 *unstructured.Unstructured) error {
+func (fake *FakeRepository) AssureObjectExistsOnCluster(arg1 *unstructured.Unstructured) error {
 	fake.createOrPatchUnstructuredObjectMutex.Lock()
 	ret, specificReturn := fake.createOrPatchUnstructuredObjectReturnsOnCall[len(fake.createOrPatchUnstructuredObjectArgsForCall)]
 	fake.createOrPatchUnstructuredObjectArgsForCall = append(fake.createOrPatchUnstructuredObjectArgsForCall, struct {
@@ -110,7 +110,7 @@ func (fake *FakeRepository) CreateOrPatchUnstructuredObject(arg1 *unstructured.U
 	}{arg1})
 	stub := fake.CreateOrPatchUnstructuredObjectStub
 	fakeReturns := fake.createOrPatchUnstructuredObjectReturns
-	fake.recordInvocation("CreateOrPatchUnstructuredObject", []interface{}{arg1})
+	fake.recordInvocation("AssureObjectExistsOnCluster", []interface{}{arg1})
 	fake.createOrPatchUnstructuredObjectMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)

--- a/releases/release.yaml
+++ b/releases/release.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -29,55 +28,51 @@ spec:
     singular: clusterconfigtemplate
   scope: Cluster
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              configPath:
-                type: string
-              params:
-                items:
-                  properties:
-                    default:
-                      x-kubernetes-preserve-unknown-fields: true
-                    name:
-                      type: string
-                  required:
-                  - default
-                  - name
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                configPath:
+                  type: string
+                params:
+                  items:
+                    properties:
+                      default:
+                        x-kubernetes-preserve-unknown-fields: true
+                      name:
+                        type: string
+                    required:
+                      - default
+                      - name
+                    type: object
+                  type: array
+                template:
                   type: object
-                type: array
-              template:
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-            required:
-            - configPath
-            - template
-            type: object
-          status:
-            type: object
-        required:
-        - metadata
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  x-kubernetes-preserve-unknown-fields: true
+              required:
+                - configPath
+                - template
+              type: object
+            status:
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""
@@ -101,55 +96,51 @@ spec:
     singular: clusterimagetemplate
   scope: Cluster
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              imagePath:
-                type: string
-              params:
-                items:
-                  properties:
-                    default:
-                      x-kubernetes-preserve-unknown-fields: true
-                    name:
-                      type: string
-                  required:
-                  - default
-                  - name
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                imagePath:
+                  type: string
+                params:
+                  items:
+                    properties:
+                      default:
+                        x-kubernetes-preserve-unknown-fields: true
+                      name:
+                        type: string
+                    required:
+                      - default
+                      - name
+                    type: object
+                  type: array
+                template:
                   type: object
-                type: array
-              template:
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-            required:
-            - imagePath
-            - template
-            type: object
-          status:
-            type: object
-        required:
-        - metadata
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  x-kubernetes-preserve-unknown-fields: true
+              required:
+                - imagePath
+                - template
+              type: object
+            status:
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""
@@ -173,58 +164,54 @@ spec:
     singular: clustersourcetemplate
   scope: Cluster
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              params:
-                items:
-                  properties:
-                    default:
-                      x-kubernetes-preserve-unknown-fields: true
-                    name:
-                      type: string
-                  required:
-                  - default
-                  - name
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                params:
+                  items:
+                    properties:
+                      default:
+                        x-kubernetes-preserve-unknown-fields: true
+                      name:
+                        type: string
+                    required:
+                      - default
+                      - name
+                    type: object
+                  type: array
+                revisionPath:
+                  type: string
+                template:
                   type: object
-                type: array
-              revisionPath:
-                type: string
-              template:
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              urlPath:
-                type: string
-            required:
-            - revisionPath
-            - template
-            - urlPath
-            type: object
-          status:
-            type: object
-        required:
-        - metadata
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  x-kubernetes-preserve-unknown-fields: true
+                urlPath:
+                  type: string
+              required:
+                - revisionPath
+                - template
+                - urlPath
+              type: object
+            status:
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""
@@ -248,189 +235,159 @@ spec:
     singular: clustersupplychain
   scope: Cluster
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              components:
-                items:
-                  properties:
-                    configs:
-                      items:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                components:
+                  items:
+                    properties:
+                      configs:
+                        items:
+                          properties:
+                            component:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                            - component
+                            - name
+                          type: object
+                        type: array
+                      images:
+                        items:
+                          properties:
+                            component:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                            - component
+                            - name
+                          type: object
+                        type: array
+                      name:
+                        type: string
+                      params:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                            - name
+                            - value
+                          type: object
+                        type: array
+                      sources:
+                        items:
+                          properties:
+                            component:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                            - component
+                            - name
+                          type: object
+                        type: array
+                      templateRef:
                         properties:
-                          component:
+                          kind:
+                            enum:
+                              - ClusterSourceTemplate
+                              - ClusterImageTemplate
+                              - ClusterTemplate
+                              - ClusterConfigTemplate
                             type: string
                           name:
+                            minLength: 1
                             type: string
                         required:
-                        - component
-                        - name
+                          - kind
+                          - name
                         type: object
-                      type: array
-                    images:
-                      items:
-                        properties:
-                          component:
-                            type: string
-                          name:
-                            type: string
-                        required:
-                        - component
-                        - name
-                        type: object
-                      type: array
-                    name:
-                      type: string
-                    params:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                          value:
-                            x-kubernetes-preserve-unknown-fields: true
-                        required:
-                        - name
-                        - value
-                        type: object
-                      type: array
-                    sources:
-                      items:
-                        properties:
-                          component:
-                            type: string
-                          name:
-                            type: string
-                        required:
-                        - component
-                        - name
-                        type: object
-                      type: array
-                    templateRef:
-                      properties:
-                        kind:
-                          enum:
-                          - ClusterSourceTemplate
-                          - ClusterImageTemplate
-                          - ClusterTemplate
-                          - ClusterConfigTemplate
-                          type: string
-                        name:
-                          minLength: 1
-                          type: string
-                      required:
-                      - kind
+                    required:
                       - name
-                      type: object
-                  required:
-                  - name
-                  - templateRef
+                      - templateRef
+                    type: object
+                  type: array
+                selector:
+                  additionalProperties:
+                    type: string
                   type: object
-                type: array
-              selector:
-                additionalProperties:
-                  type: string
-                type: object
-            required:
-            - components
-            - selector
-            type: object
-          status:
-            properties:
-              conditions:
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-              observedGeneration:
-                format: int64
-                type: integer
-            type: object
-        required:
-        - metadata
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+              required:
+                - components
+                - selector
+              type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                observedGeneration:
+                  format: int64
+                  type: integer
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""
@@ -454,52 +411,48 @@ spec:
     singular: clustertemplate
   scope: Cluster
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              params:
-                items:
-                  properties:
-                    default:
-                      x-kubernetes-preserve-unknown-fields: true
-                    name:
-                      type: string
-                  required:
-                  - default
-                  - name
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                params:
+                  items:
+                    properties:
+                      default:
+                        x-kubernetes-preserve-unknown-fields: true
+                      name:
+                        type: string
+                    required:
+                      - default
+                      - name
+                    type: object
+                  type: array
+                template:
                   type: object
-                type: array
-              template:
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-            required:
-            - template
-            type: object
-          status:
-            type: object
-        required:
-        - metadata
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  x-kubernetes-preserve-unknown-fields: true
+              required:
+                - template
+              type: object
+            status:
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""
@@ -523,33 +476,29 @@ spec:
     singular: deliverable
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          value:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        required:
-        - metadata
-        - value
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            value:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          required:
+            - metadata
+            - value
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""
@@ -573,172 +522,228 @@ spec:
     singular: workload
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              env:
-                items:
-                  description: EnvVar represents an environment variable present in
-                    a Container.
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                env:
+                  items:
+                    description: EnvVar represents an environment variable present in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value. Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified API version.
+                                type: string
+                            required:
+                              - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes, optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                              - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                        type: object
+                    required:
+                      - name
+                    type: object
+                  type: array
+                image:
+                  description: Image is a pre-built image in a registry. It is an alternative to defining source code.
+                  type: string
+                params:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        x-kubernetes-preserve-unknown-fields: true
+                    required:
+                      - name
+                      - value
+                    type: object
+                  type: array
+                resources:
+                  description: ResourceRequirements describes the compute resource requirements.
                   properties:
-                    name:
-                      description: Name of the environment variable. Must be a C_IDENTIFIER.
-                      type: string
-                    value:
-                      description: 'Variable references $(VAR_NAME) are expanded using
-                        the previously defined environment variables in the container
-                        and any service environment variables. If a variable cannot
-                        be resolved, the reference in the input string will be unchanged.
-                        Double $$ are reduced to a single $, which allows for escaping
-                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
-                        string literal "$(VAR_NAME)". Escaped references will never
-                        be expanded, regardless of whether the variable exists or
-                        not. Defaults to "".'
-                      type: string
-                    valueFrom:
-                      description: Source for the environment variable's value. Cannot
-                        be used if value is not empty.
-                      properties:
-                        configMapKeyRef:
-                          description: Selects a key of a ConfigMap.
-                          properties:
-                            key:
-                              description: The key to select.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the ConfigMap or its key
-                                must be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                        fieldRef:
-                          description: 'Selects a field of the pod: supports metadata.name,
-                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                            spec.nodeName, spec.serviceAccountName, status.hostIP,
-                            status.podIP, status.podIPs.'
-                          properties:
-                            apiVersion:
-                              description: Version of the schema the FieldPath is
-                                written in terms of, defaults to "v1".
-                              type: string
-                            fieldPath:
-                              description: Path of the field to select in the specified
-                                API version.
-                              type: string
-                          required:
-                          - fieldPath
-                          type: object
-                        resourceFieldRef:
-                          description: 'Selects a resource of the container: only
-                            resources limits and requests (limits.cpu, limits.memory,
-                            limits.ephemeral-storage, requests.cpu, requests.memory
-                            and requests.ephemeral-storage) are currently supported.'
-                          properties:
-                            containerName:
-                              description: 'Container name: required for volumes,
-                                optional for env vars'
-                              type: string
-                            divisor:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              description: Specifies the output format of the exposed
-                                resources, defaults to "1"
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            resource:
-                              description: 'Required: resource to select'
-                              type: string
-                          required:
-                          - resource
-                          type: object
-                        secretKeyRef:
-                          description: Selects a key of a secret in the pod's namespace
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                       type: object
-                  required:
-                  - name
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
                   type: object
-                type: array
-              image:
-                description: Image is a pre-built image in a registry. It is an alternative
-                  to defining source code.
-                type: string
-              params:
-                items:
+                serviceClaims:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      ref:
+                        properties:
+                          apiVersion:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                          - apiVersion
+                          - kind
+                          - name
+                        type: object
+                    required:
+                      - name
+                    type: object
+                  type: array
+                source:
                   properties:
-                    name:
+                    git:
+                      properties:
+                        ref:
+                          properties:
+                            branch:
+                              type: string
+                            commit:
+                              type: string
+                            tag:
+                              type: string
+                          type: object
+                        url:
+                          type: string
+                      type: object
+                    image:
+                      description: Image is an OCI image is a registry that contains source code
                       type: string
-                    value:
-                      x-kubernetes-preserve-unknown-fields: true
-                  required:
-                  - name
-                  - value
                   type: object
-                type: array
-              resources:
-                description: ResourceRequirements describes the compute resource requirements.
-                properties:
-                  limits:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+              type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
                     type: object
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                    type: object
-                type: object
-              services:
-                items:
+                  type: array
+                observedGeneration:
+                  format: int64
+                  type: integer
+                supplyChainRef:
                   properties:
                     apiVersion:
                       type: string
@@ -749,124 +754,15 @@ spec:
                     namespace:
                       type: string
                   type: object
-                type: array
-              source:
-                properties:
-                  git:
-                    properties:
-                      ref:
-                        properties:
-                          branch:
-                            type: string
-                          commit:
-                            type: string
-                          tag:
-                            type: string
-                        type: object
-                      url:
-                        type: string
-                    type: object
-                  imgpkgBundle:
-                    properties:
-                      image:
-                        type: string
-                    type: object
-                type: object
-            type: object
-          status:
-            properties:
-              conditions:
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-              observedGeneration:
-                format: int64
-                type: integer
-              supplyChainRef:
-                properties:
-                  apiVersion:
-                    type: string
-                  kind:
-                    type: string
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                type: object
-            type: object
-        required:
-        - metadata
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""
@@ -880,44 +776,44 @@ metadata:
   name: cartographer-controller
   namespace: cartographer-system
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: cartographer-controller
+  replicas: 1
   template:
     metadata:
       labels:
         app: cartographer-controller
     spec:
-      containers:
-      - args:
-        - -cert-dir=/cert
-        image: index.docker.io/projectcartographer/cartographer-controller@sha256:2d248d88f6647f04d432023480406559bbfdb97907c59de1c5f4342785159f42
-        name: cartographer-controller
-        resources:
-          limits:
-            cpu: 1
-            memory: 200Mi
-          requests:
-            cpu: 200m
-            memory: 200Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - all
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-        volumeMounts:
-        - mountPath: /cert
-          name: cert
-          readOnly: true
       serviceAccount: cartographer-controller
       volumes:
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: cartographer-webhook
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: cartographer-webhook
+      containers:
+        - name: cartographer-controller
+          image: 192.168.0.108:5000/controller/cmd-72b2fdd4563b5da9ab700e504fe28dcd@sha256:9321488b0f837dfd6ecb3511aced50cc3691f1601e3b8da0d156ecf0e2001d79
+          args:
+            - -cert-dir=/cert
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - all
+          volumeMounts:
+            - mountPath: /cert
+              name: cert
+              readOnly: true
+          resources:
+            limits:
+              cpu: 1
+              memory: 200Mi
+            requests:
+              cpu: 200m
+              memory: 200Mi
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -934,38 +830,38 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
-- kind: ServiceAccount
-  name: cartographer-controller
-  namespace: cartographer-system
+  - kind: ServiceAccount
+    name: cartographer-controller
+    namespace: cartographer-system
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  name: clustersupplychainvalidator
   annotations:
     cert-manager.io/inject-ca-from: cartographer-system/cartographer-webhook
-  name: clustersupplychainvalidator
 webhooks:
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: cartographer-webhook
-      namespace: cartographer-system
-      path: /validate-carto-run-v1alpha1-clustersupplychain
-  name: supply-chain-validator.cartographer.com
-  rules:
-  - apiGroups:
-    - carto.run
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - clustersupplychains
-    scope: Cluster
-  sideEffects: None
+  - name: supply-chain-validator.cartographer.com
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - carto.run
+        apiVersions:
+          - v1alpha1
+        resources:
+          - clustersupplychains
+        scope: Cluster
+    clientConfig:
+      service:
+        name: cartographer-webhook
+        namespace: cartographer-system
+        path: /validate-carto-run-v1alpha1-clustersupplychain
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+      - v1beta1
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
@@ -975,8 +871,8 @@ metadata:
 spec:
   commonName: cartographer-webhook.cartographer-system.svc
   dnsNames:
-  - cartographer-webhook.cartographer-system.svc
-  - cartographer-webhook.cartographer-system.svc.cluster.local
+    - cartographer-webhook.cartographer-system.svc
+    - cartographer-webhook.cartographer-system.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
@@ -997,13 +893,15 @@ metadata:
   namespace: cartographer-system
 spec:
   ports:
-  - port: 443
-    targetPort: 9443
+    - port: 443
+      targetPort: 9443
   selector:
     app: cartographer-controller
 ---
-apiVersion: v1
 kind: Secret
+apiVersion: v1
 metadata:
   name: cartographer-webhook
   namespace: cartographer-system
+
+---


### PR DESCRIPTION
In the case that the apiServer returns a previously created object
and that object does not need to be altered, ensure that object
is available to the calling function (and subsequently the
StampContext).

Authored-by: Waciuma Wanjohi <lwanjohi@pivotal.io>