### PR TITLE
Add unit tests for registrar functions

### DIFF
--- a/pkg/apis/v1alpha1/cluster_supply_chain.go
+++ b/pkg/apis/v1alpha1/cluster_supply_chain.go
@@ -24,6 +24,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -120,6 +121,20 @@ func (c *ClusterSupplyChain) ValidateUpdate(_ runtime.Object) error {
 
 func (c *ClusterSupplyChain) ValidateDelete() error {
 	return nil
+}
+
+func GetSelectorsFromObject(o client.Object) []string {
+	var res []string
+	res = []string{}
+
+	sc, ok := o.(*ClusterSupplyChain)
+	if ok {
+		for key, value := range sc.Spec.Selector {
+			res = append(res, fmt.Sprintf("%s: %s", key, value))
+		}
+	}
+
+	return res
 }
 
 type SupplyChainSpec struct {

--- a/pkg/apis/v1alpha1/cluster_supply_chain_test.go
+++ b/pkg/apis/v1alpha1/cluster_supply_chain_test.go
@@ -429,4 +429,59 @@ var _ = Describe("ClusterSupplyChain", func() {
 		})
 
 	})
+
+	Describe("GetSelectorsFromObject", func() {
+		var expectedSelectors, actualSelectors []string
+		Context("when object is a supply chain", func() {
+			var sc *v1alpha1.ClusterSupplyChain
+
+			BeforeEach(func() {
+				sc = &v1alpha1.ClusterSupplyChain{Spec: v1alpha1.SupplyChainSpec{}}
+			})
+			Context("given a supply chain with 0 selectors", func() {
+				BeforeEach(func() {
+					actualSelectors = v1alpha1.GetSelectorsFromObject(sc)
+				})
+				It("returns an empty list", func() {
+					expectedSelectors = []string{}
+					Expect(actualSelectors).To(ConsistOf(expectedSelectors))
+				})
+			})
+			Context("given a supply chain with 1 selector", func() {
+				BeforeEach(func() {
+					sc.Spec.Selector = map[string]string{"some-key": "some-val"}
+					actualSelectors = v1alpha1.GetSelectorsFromObject(sc)
+				})
+
+				It("returns a list with only the string concatenation of the key-value", func() {
+					expectedSelectors = []string{"some-key: some-val"}
+					Expect(actualSelectors).To(ConsistOf(expectedSelectors))
+				})
+			})
+			Context("given a supply chain with many selectors", func() {
+				BeforeEach(func() {
+					sc.Spec.Selector = map[string]string{
+						"some-key":    "some-val",
+						"another-key": "another-val",
+					}
+					actualSelectors = v1alpha1.GetSelectorsFromObject(sc)
+				})
+
+				It("returns a list with string concatenations of each key-value", func() {
+					expectedSelectors = []string{"some-key: some-val", "another-key: another-val"}
+					Expect(actualSelectors).To(ConsistOf(expectedSelectors))
+				})
+			})
+		})
+
+		Context("when object is not a supply chain", func() {
+			BeforeEach(func() {
+				actualSelectors = v1alpha1.GetSelectorsFromObject(&v1alpha1.Workload{})
+			})
+			It("returns an empty list", func() {
+				expectedSelectors = []string{}
+				Expect(actualSelectors).To(ConsistOf(expectedSelectors))
+			})
+		})
+	})
 })

--- a/pkg/registrar/registrar.go
+++ b/pkg/registrar/registrar.go
@@ -126,16 +126,7 @@ func IndexResources(mgr manager.Manager, ctx context.Context) error {
 }
 
 func indexSupplyChains(ctx context.Context, fieldIndexer client.FieldIndexer) error {
-	err := fieldIndexer.IndexField(ctx, &v1alpha1.ClusterSupplyChain{}, "spec.selector",
-		func(o client.Object) []string {
-			sc := o.(*v1alpha1.ClusterSupplyChain)
-			var res []string
-			for key, value := range sc.Spec.Selector {
-				res = append(res, fmt.Sprintf("%s: %s", key, value))
-			}
-
-			return res
-		})
+	err := fieldIndexer.IndexField(ctx, &v1alpha1.ClusterSupplyChain{}, "spec.selector", v1alpha1.GetSelectorsFromObject)
 	if err != nil {
 		return fmt.Errorf("index field supply-chain.selector: %w", err)
 	}

--- a/pkg/registrar/registrar_test.go
+++ b/pkg/registrar/registrar_test.go
@@ -1,0 +1,74 @@
+package registrar_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/vmware-tanzu/cartographer/pkg/registrar"
+)
+
+var _ = Describe("Registrar", func() {
+	Describe("Now", func() {
+		var testTime time.Time
+		Context("when Now is called", func() {
+			BeforeEach(func() {
+				timer := registrar.Timer{}
+				testTime = timer.Now().Time
+			})
+
+			It("returns the current time", func() {
+				Expect(time.Since(testTime)).To(BeNumerically("<", time.Second))
+			})
+		})
+	})
+
+	Describe("AddToScheme", func() {
+		Context("when passing in a scheme", func() {
+			var scheme *runtime.Scheme
+			BeforeEach(func() {
+				scheme = runtime.NewScheme()
+				Expect(registrar.AddToScheme(scheme)).To(Succeed())
+			})
+
+			It("registers the cartographer group", func() {
+				Expect(scheme.IsGroupRegistered("carto.run")).To(BeTrue())
+			})
+
+			It("creates a scheme with expected length", func() {
+				gv := schema.GroupVersion{
+					Group:   "carto.run",
+					Version: "v1alpha1",
+				}
+				Expect(len(scheme.KnownTypes(gv))).To(Equal(21))
+				// If this test fails, it may indicate that new types should be added to the test below
+			})
+
+			It("adds the cartographer objects to the scheme", func() {
+				baseGVK := schema.GroupVersionKind{
+					Group:   "carto.run",
+					Version: "v1alpha1",
+				}
+
+				kinds := []string{
+					"ClusterConfigTemplate",
+					"ClusterImageTemplate",
+					"ClusterSourceTemplate",
+					"ClusterSupplyChain",
+					"ClusterTemplate",
+					"Deliverable",
+					"Workload",
+				}
+
+				for _, kind := range kinds {
+					baseGVK.Kind = kind
+					Expect(scheme.Recognizes(baseGVK)).To(BeTrue(), fmt.Sprintf("scheme should have kind: %s", kind))
+				}
+			})
+		})
+	})
+})

--- a/pkg/registrar/registrar_test.go
+++ b/pkg/registrar/registrar_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 VMware
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package registrar_test
 
 import (


### PR DESCRIPTION
Moves anonymous function for indexing supply chains to
the supply chain definition file.

closes #19

Authored-by: Waciuma Wanjohi <lwanjohi@pivotal.io>