### PR TITLE
examples: bump source-controller

### DIFF
--- a/examples/source-to-knative-service/README.md
+++ b/examples/source-to-knative-service/README.md
@@ -84,8 +84,8 @@ kubectl create clusterrolebinding gitops-toolkit-admin \
 
 kapp deploy --yes -a gitops-toolkit \
   --into-ns gitops-toolkit \
-  -f https://github.com/fluxcd/source-controller/releases/download/v0.15.3/source-controller.crds.yaml \
-  -f https://github.com/fluxcd/source-controller/releases/download/v0.15.3/source-controller.deployment.yaml
+  -f https://github.com/fluxcd/source-controller/releases/download/v0.15.4/source-controller.crds.yaml \
+  -f https://github.com/fluxcd/source-controller/releases/download/v0.15.4/source-controller.deployment.yaml
 ```
 
 - [kapp-controller], for providing us with the ability of deploying multiple

--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -177,8 +177,8 @@ install_source_controller() {
 
         ytt --ignore-unknown-comments \
                 -f $DIR/overlays/remove-resource-requests-from-deployments.yaml \
-                -f https://github.com/fluxcd/source-controller/releases/download/v0.15.3/source-controller.crds.yaml \
-                -f https://github.com/fluxcd/source-controller/releases/download/v0.15.3/source-controller.deployment.yaml |
+                -f https://github.com/fluxcd/source-controller/releases/download/v0.15.4/source-controller.crds.yaml \
+                -f https://github.com/fluxcd/source-controller/releases/download/v0.15.4/source-controller.deployment.yaml |
                 kapp deploy --yes -a gitops-toolkit --into-ns gitops-toolkit -f-
 }
 


### PR DESCRIPTION
v0.15.4 includes a fix to the way the tarball gets produced - rather
than letting it use the default behavior or including timestamps, do it
so with them zerod out so it's predictable.

see https://github.com/fluxcd/source-controller/commit/3ac39b6137853cf135d997623ff25ef034dcfc6d

no behavior change.

---

to validate:

1. go to the commit prior to this (e.g., 6bf6d3fd6e1e36a014f629f9ef420b00459178cb), run the examples (`./hack/ci/e2e.sh`)
2. notice that in a period of ~20s, the checksum changes a few times  (`k get gitrepository dev -o jsonpath={.status.artifact.checksum}`)

3. tear it down (although just upgrading source-controller should work, I'd guess)
4. get to this branch
5. run it again and notice that checksum doesn't change anymore