### PR TITLE
Errors if an input references an unknown component

### DIFF
--- a/tests/integration/supply_chain/supply_chain_validation_test.go
+++ b/tests/integration/supply_chain/supply_chain_validation_test.go
@@ -273,7 +273,7 @@ var _ = Describe("SupplyChainValidation", func() {
 			It("Rejects the supply chain", func() {
 				err = c.Create(ctx, supplyChain)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("Source 'provider' for 'build-image-provider' component must reference a ClusterSourceTemplate"))
+				Expect(err.Error()).To(ContainSubstring("component 'provider' providing 'solo-source-provider' must reference a ClusterSourceTemplate"))
 			})
 		})
 	})


### PR DESCRIPTION
* Also tweaks provider type mismatch error messages to be (hopefully) less confusing

Signed-off-by: Emily Casey <ecasey@vmware.com>

Resolves #3 