### PR TITLE
ko: use tiny-cnb as final base image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,1 @@
+defaultBaseImage: gcr.io/paketo-buildpacks/run:tiny-cnb

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,15 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 defaultBaseImage: gcr.io/paketo-buildpacks/run:tiny-cnb


### PR DESCRIPTION
we're currently building the container image that runs our controller
using the default base image that `ko` sets - distroless/static:nonroot
(see [1]).

while that has been working great so far, we can do even better by
leveraging tiny-cnb ([2]) which, being ubuntu-based (rather than
debian-based) and maintained by folks that we can get in touch
faster, in case of a cve to any of the base packages (even
though the set of packages is ... _very_ small) we can issue
patches in a more quick manner.

ps.: package-wise, yes, distroless _is_ better when it comes to attack
surface as it indeed has less packages:

- `distroless/static:nonroot`
```
	Desired=Unknown/Install/Remove/Purge/Hold
	| Status=Not/Inst/Conf-files/Unpacked/halF-c...
	|/ Err?=(none)/Reinst-required (Status,Err: ...
	||/ Name       Version         Architecture ...
	+++-==========-===============-============-...
	ii  base-files 10.3+deb10u10   amd64        ...
	ii  netbase    5.6             all          ...
	ii  tzdata     2021a-0+deb10u1 all          ...
```

- `run:tiny-cnb`

```
	Desired=Unknown/Install/Remove/Purge/Hold
	| Status=Not/Inst/Conf-files/Unpacked/halF-con...
	|/ Err?=(none)/Reinst-required (Status,Err: up...
	||/ Name            Version                   ...
	+++-===============-=========================-...
	ii  base-files      10.1ubuntu2.11            ...
	ii  ca-certificates 20210119~18.04.1          ...
	ii  libc6           2.27-3ubuntu1.4           ...
	ii  libssl1.1       1.1.1-1ubuntu2.1~18.04.13 ...
	ii  netbase         5.4                       ...
	ii  openssl         1.1.1-1ubuntu2.1~18.04.13 ...
	ii  tzdata          2021a-0ubuntu0.18.04      ...
	ii  zlib1g          1:1.2.11.dfsg-0ubuntu2    ...
```

[1]: https://github.com/google/ko/blob/61d5250c555f254203b74fe9510bef96db82d7f4/pkg/commands/config.go#L46
[2]: https://github.com/paketo-buildpacks/stacks#metadata-for-paketo-buildrun-stack-images

Signed-off-by: Ciro S. Costa <ciroscosta@vmware.com>