### PR TITLE
hack: fix tag resolution

### DIFF
--- a/hack/publish-github-release.sh
+++ b/hack/publish-github-release.sh
@@ -38,8 +38,7 @@ submit_release_to_github() {
 }
 
 git_current_version() {
-        git tag --sort=-v:refname -l 'v*' |
-                head -n1
+        git tag --points-at HEAD
 }
 
 main "$@"


### PR DESCRIPTION
by making use of `--point-at` we can grab the correct tag not relying on
any sorting

Signed-off-by: Ciro S. Costa <ciroscosta@vmware.com>