### PR TITLE
Example writes image to registry server configured in values.yaml

### DIFF
--- a/examples/source-to-knative-service/00-cluster/kpack.yaml
+++ b/examples/source-to-knative-service/00-cluster/kpack.yaml
@@ -42,7 +42,7 @@ spec:
   serviceAccountRef:
     name: service-account
     namespace: default
-  tag: #@ data.values.image_prefix + "go-builder"
+  tag: #@ data.values.registry.server + "/" + data.values.image_prefix + "go-builder"
   stack:
     name: stack
     kind: ClusterStack

--- a/examples/source-to-knative-service/app-operator/supply-chain-templates.yaml
+++ b/examples/source-to-knative-service/app-operator/supply-chain-templates.yaml
@@ -64,7 +64,7 @@ spec:
     metadata:
       name: $(workload.metadata.name)$
     spec:
-      tag: #@ data.values.image_prefix + "$(workload.metadata.name)$"
+      tag: #@ data.values.registry.server + "/" + data.values.image_prefix + "$(workload.metadata.name)$"
       serviceAccount: service-account
       builder:
         kind: ClusterBuilder

--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -239,7 +239,7 @@ setup_example() {
                 --data-value registry.server=$REGISTRY \
                 --data-value registry.username=admin \
                 --data-value registry.password=admin \
-                --data-value image_prefix="$REGISTRY/example-" |
+                --data-value image_prefix="example-" |
                 kapp deploy --yes -a example -f-
 }
 


### PR DESCRIPTION
I made this change to the example templating after running into an auth error after manually running the example against a local registry.

It is no longer expected that users repeat the registry url in [image prefix in values.yaml](https://github.com/vmware-tanzu/cartographer/blob/main/examples/source-to-knative-service/values.yaml#L17).

Before this change I found the example image prefix value misleading b/c it omitted the registry which will only work against Dockerhub.