### PR TITLE
Fix issue where hack/docker-login.sh creates an empty config.json

### DIFF
--- a/hack/docker-login.sh
+++ b/hack/docker-login.sh
@@ -40,7 +40,8 @@ update_or_create_docker_config() {
                 echo '{}' >$config_file
         fi
 
-        cat $config_file | jq "$(printf "$qry" $server $token)" >$config_file
+        config=$(jq "$(printf "$qry" $server $token)" < "$config_file")
+        echo "$config" > $config_file
 }
 
 basic_auth() {


### PR DESCRIPTION
I am not entirely sure why this happens but I have seen this in other contexts as well on macOS. Sometimes when piping output from `jq` the value is lost.

Signed-off-by: Emily Casey <ecasey@vmware.com>