### PR TITLE
github: add issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,17 @@
+_"I want to <x>"_
+
+```gherkin
+Given <Some Condition>
+When <Something Happens>
+Then <This other thing should happen?
+```
+
+
+### Example
+
+<Code snippets that illustrate the when/then blocks>
+
+
+## Additional Context
+
+<Additional notes>


### PR DESCRIPTION
this is a straight port of what we had before in the gitlab repository.

hitting "new issue" will bring:

<img width="833" alt="Screen Shot 2021-09-23 at 2 04 55 PM" src="https://user-images.githubusercontent.com/3574444/134560320-f01377fd-ddb3-4da7-ad87-3ef0b31ae58b.png">

