### PR TITLE
Revert "Example writes image to registry server configured in values.yaml"

### DIFF
--- a/examples/source-to-knative-service/00-cluster/kpack.yaml
+++ b/examples/source-to-knative-service/00-cluster/kpack.yaml
@@ -42,7 +42,7 @@ spec:
   serviceAccountRef:
     name: service-account
     namespace: default
-  tag: #@ data.values.registry.server + "/" + data.values.image_prefix + "go-builder"
+  tag: #@ data.values.image_prefix + "go-builder"
   stack:
     name: stack
     kind: ClusterStack

--- a/examples/source-to-knative-service/app-operator/supply-chain-templates.yaml
+++ b/examples/source-to-knative-service/app-operator/supply-chain-templates.yaml
@@ -64,7 +64,7 @@ spec:
     metadata:
       name: $(workload.metadata.name)$
     spec:
-      tag: #@ data.values.registry.server + "/" + data.values.image_prefix + "$(workload.metadata.name)$"
+      tag: #@ data.values.image_prefix + "$(workload.metadata.name)$"
       serviceAccount: service-account
       builder:
         kind: ClusterBuilder

--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -239,7 +239,7 @@ setup_example() {
                 --data-value registry.server=$REGISTRY \
                 --data-value registry.username=admin \
                 --data-value registry.password=admin \
-                --data-value image_prefix="example-" |
+                --data-value image_prefix="$REGISTRY/example-" |
                 kapp deploy --yes -a example -f-
 }
 


### PR DESCRIPTION
Reverts vmware-tanzu/cartographer#149

Sorry. this change was a bit hasty. It was working for me b/c I did not include `https` in my value for server, but it doesn't work with the dockerhub example. Also not sure how strict the formatting requirements are in the secret.