### PR TITLE
hack: include tekton in the setup

### DIFF
--- a/hack/overlays/remove-resource-requests-from-deployments.yaml
+++ b/hack/overlays/remove-resource-requests-from-deployments.yaml
@@ -14,19 +14,29 @@
 
 #@ load("@ytt:overlay", "overlay")
 
-#@overlay/match by=overlay.subset({"kind":"Deployment"}), expects="1+"
+#! Remove resource requirements to support smaller environments
+
+#@ is_dep = overlay.subset({"kind": "Deployment"})
+#@ is_ds = overlay.subset({"kind": "DaemonSet"})
+#@ is_sts = overlay.subset({"kind": "StatefulSet"})
+
+#@overlay/match by=overlay.or_op(is_dep, is_ds, is_sts),expects="1+"
 ---
 spec:
-  #@overlay/match
   template:
     spec:
-      #@overlay/match
+      #@overlay/match when=1
+      initContainers:
+      #@overlay/match by=overlay.all,when="1+"
+      -
+        #@overlay/match missing_ok=True
+        #@overlay/remove
+        resources: {}
+
+      #@overlay/match when=1
       containers:
-        #@overlay/match by=overlay.all,expects="0+"
-        - resources:
-            #@overlay/match missing_ok=True
-            #@overlay/replace
-            requests: {}
-            #@overlay/match missing_ok=True
-            #@overlay/replace
-            limits: {}
+      #@overlay/match by=overlay.all,when="1+"
+      -
+        #@overlay/match missing_ok=True
+        #@overlay/remove
+        resources: {}

--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -33,6 +33,7 @@ readonly KNATIVE_SERVING_VERSION=0.25.0
 readonly KPACK_VERSION=0.3.1
 readonly SECRETGEN_CONTROLLER_VERSION=0.5.0
 readonly SOURCE_CONTROLLER_VERSION=0.15.4
+readonly TEKTON_VERSION=0.28.0
 
 main() {
         test $# -eq 0 && show_usage_help
@@ -56,6 +57,7 @@ main() {
                         install_source_controller
                         install_kpack
                         install_knative_serving
+                        install_tekton
                         ;;
 
                 example)
@@ -231,6 +233,13 @@ install_knative_serving() {
                 -f https://github.com/knative/serving/releases/download/v$KNATIVE_SERVING_VERSION/serving-crds.yaml \
                 -f $DIR/overlays/remove-resource-requests-from-deployments.yaml |
                 kapp deploy --yes -a knative-serving -f-
+}
+
+install_tekton() {
+        ytt --ignore-unknown-comments \
+                -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v$TEKTON_VERSION/release.yaml \
+                -f $DIR/overlays/remove-resource-requests-from-deployments.yaml |
+                kapp deploy --yes -a tekton -f-
 }
 
 setup_example() {


### PR DESCRIPTION
```
----

    hack: add tekton to example-deps setup

    although the example does not include tekton _yet_, it will *very
    soon*^tm

-----

    hack: improve resource removal overlay

    the previous form of overlay that we had was very specific to matching
    only deployments that were already making use of `resources`.

    it turns out that `tekton` doesn't, so it wouldn't be covered.

    given that it's also very likely that there might be other gvrs that
    we'd want to cover (like deployment, daemonsets and statefulsets), this
    takes care of all of that.
```

overlay based on https://github.com/vmware-tanzu/carvel-ytt/blob/47d49cce99b3a2a9ba5197565bc6ff07367a216b/examples/k8s-overlay-remove-resources/overlay.yml