### PR TITLE
Clean up TOC for CRD reference

### DIFF
--- a/site/content/docs/reference.md
+++ b/site/content/docs/reference.md
@@ -26,15 +26,15 @@ kind: ClusterSupplyChain
 
 Cartographer is composed of several custom resources, some of them being cluster-wide:
 
-- `ClusterSupplyChain`
-- `ClusterSourceTemplate`
-- `ClusterImageTemplate`
-- `ClusterConfigTemplate`
-- `ClusterTemplate`
+- [`ClusterSupplyChain`](#clustersupplychain)
+- [`ClusterSourceTemplate`](#clustersourcetemplate)
+- [`ClusterImageTemplate`](#clusterimagetemplate)
+- [`ClusterConfigTemplate`](#clusterconfigtemplate)
+- [`ClusterTemplate`](#clustertemplate)
 
-and two that are namespace-scoped:
+and one that is namespace-scoped:
 
-- `Workload`
+- [`Workload`](#workload)
 
 
 ### Workload


### PR DESCRIPTION
I got confused by the reference to "two namespace-scoped resources" when only one was listed, so I added links as well.