### PR TITLE
make release publish images to dockerhub

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,8 +55,20 @@ jobs:
           KUBEBUILDER_ASSETS: /usr/local/bin
         run: make test
 
-      - name: run e2e example
-        run: ./hack/setup.sh cluster cartographer example-dependencies example
+      - name: setup the cluster and local registry with all dependencies needed
+        run: ./hack/setup.sh cluster example-dependencies
+
+      - name: generate a cartographer release and install it
+        env:
+          REGISTRY: projectcartographer
+          DOCKER_USERNAME: projectcartographer
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |-
+          ./hack/docker-login.sh
+          ./hack/setup.sh cartographer
+
+      - name: submit the example and assert that it worked
+        run: ./hack/setup.sh example
 
       - name: submit github release
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,7 +230,7 @@ RELEASE_VERSION=v0.0.6-rc ./hack/release.sh
 3. submit to github
 
 ```bash
-RELEASE_VERSION=v0.0.6-rc ./hack/release.sh
+RELEASE_VERSION=v0.0.6-rc ./hack/publish-github-release.sh
 ```
 
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -163,13 +163,15 @@ create_release_notes() {
 # 	│   └── package-metadata.yaml
 # 	│   └── package.yaml
 # 	│
-# 	└── bundle.tar.gz
+# 	├── cartographer.yaml
+# 	└── bundle.tar
 #
 populate_release_directory() {
         rm -rf ./release
         mkdir -p ./release/package
 
         cp $SCRATCH/bundle.tar ./release
+        cp $SCRATCH/bundle/config/cartographer.yaml ./release
         cp -r $SCRATCH/package ./release
 }
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -111,7 +111,7 @@ create_imgpkg_bundle() {
         cp -r ./packaging/{objects,overlays} $SCRATCH/bundle/config
 
         ytt --ignore-unknown-comments -f ./config |
-                KO_DOCKER_REPO=$REGISTRY ko resolve -f- > \
+                KO_DOCKER_REPO=$REGISTRY ko resolve -B -f- > \
                         $SCRATCH/bundle/config/cartographer.yaml
 
         kbld -f $SCRATCH/bundle/config/cartographer.yaml \


### PR DESCRIPTION
in #200 I added instructions for one to leverage a `cartographer.yaml` file that we can distribute in our releases so that all it takes to install Cartographer is a `k apply -f <latest_release>`, but I hadn't updated the automation for doing so. Here is where I tackle the automation (+ updates to the script to surface that single yaml file).

please see the commit messages for details about the changes.

(no, I haven't pushed a tag for a release yet, but, have manually ran the same steps through and it looks good)

 