### PR TITLE
Remove condition change handling

### DIFF
--- a/pkg/conditions/condition_manager_test.go
+++ b/pkg/conditions/condition_manager_test.go
@@ -31,10 +31,9 @@ var _ = Describe("conditionManager", func() {
 		})
 
 		It("returns a top level unknown", func() {
-			result, changed := manager.Finalize()
+			result := manager.Finalize()
 
 			Expect(manager.IsSuccessful()).To(BeFalse())
-			Expect(changed).To(BeTrue())
 			Expect(result).To(HaveLen(1))
 			Expect(result).To(ContainElement(MatchFields(IgnoreExtras,
 				Fields{
@@ -64,10 +63,9 @@ var _ = Describe("conditionManager", func() {
 			})
 
 			It("returns the conditions and a successful parent", func() {
-				result, changed := manager.Finalize()
+				result := manager.Finalize()
 
 				Expect(manager.IsSuccessful()).To(BeTrue())
-				Expect(changed).To(BeTrue())
 				Expect(result).To(HaveLen(3))
 				Expect(result).To(ContainElements(
 					MatchFields(IgnoreExtras,
@@ -112,11 +110,9 @@ var _ = Describe("conditionManager", func() {
 			})
 
 			It("returns the conditions and a failing parent", func() {
-				result, changed := manager.Finalize()
+				result := manager.Finalize()
 
 				Expect(manager.IsSuccessful()).To(BeFalse())
-				Expect(changed).To(BeTrue())
-
 				Expect(result).To(HaveLen(3))
 				Expect(result).To(ContainElements(
 					MatchFields(IgnoreExtras,
@@ -163,10 +159,9 @@ var _ = Describe("conditionManager", func() {
 			})
 
 			It("returns the conditions and a successful parent", func() {
-				result, changed := manager.Finalize()
+				result := manager.Finalize()
 
 				Expect(manager.IsSuccessful()).To(BeTrue())
-				Expect(changed).To(BeTrue())
 				Expect(result).To(HaveLen(3))
 				Expect(result).To(ContainElements(
 					MatchFields(IgnoreExtras,
@@ -211,10 +206,9 @@ var _ = Describe("conditionManager", func() {
 			})
 
 			It("returns the conditions and a failing parent", func() {
-				result, changed := manager.Finalize()
+				result := manager.Finalize()
 
 				Expect(manager.IsSuccessful()).To(BeFalse())
-				Expect(changed).To(BeTrue())
 				Expect(result).To(HaveLen(3))
 				Expect(result).To(ContainElements(
 					MatchFields(IgnoreExtras,
@@ -279,7 +273,7 @@ var _ = Describe("conditionManager", func() {
 			})
 
 			It("returns a parent in a bad state", func() {
-				result, _ := manager.Finalize()
+				result := manager.Finalize()
 
 				Expect(manager.IsSuccessful()).To(BeFalse())
 				Expect(result).To(ContainElement(
@@ -293,7 +287,7 @@ var _ = Describe("conditionManager", func() {
 			})
 
 			It("sets the parent reason and message to the last added bad condition", func() {
-				result, _ := manager.Finalize()
+				result := manager.Finalize()
 
 				Expect(result).To(ContainElement(
 					MatchFields(IgnoreExtras,
@@ -334,7 +328,7 @@ var _ = Describe("conditionManager", func() {
 			})
 
 			It("returns a parent in an unknown state", func() {
-				result, _ := manager.Finalize()
+				result := manager.Finalize()
 
 				Expect(manager.IsSuccessful()).To(BeTrue())
 				Expect(result).To(ContainElement(
@@ -375,7 +369,7 @@ var _ = Describe("conditionManager", func() {
 			})
 
 			It("returns a parent in a good state", func() {
-				result, _ := manager.Finalize()
+				result := manager.Finalize()
 
 				Expect(manager.IsSuccessful()).To(BeTrue())
 				Expect(result).To(ContainElement(
@@ -402,10 +396,9 @@ var _ = Describe("conditionManager", func() {
 		})
 
 		It("returns the conditions and a failing parent", func() {
-			result, changed := manager.Finalize()
+			result := manager.Finalize()
 
 			Expect(manager.IsSuccessful()).To(BeFalse())
-			Expect(changed).To(BeTrue())
 			Expect(result).To(HaveLen(2))
 			Expect(result).To(ContainElements(
 				MatchFields(IgnoreExtras,
@@ -438,10 +431,7 @@ var _ = Describe("conditionManager", func() {
 				Status: metav1.ConditionTrue,
 			}
 			manager.AddPositive(goodnessCondition)
-			var changed bool
-			firstConditions, changed = manager.Finalize()
-			Expect(changed).To(BeTrue())
-
+			firstConditions = manager.Finalize()
 		})
 
 		Context("when one of our conditions has changed", func() {
@@ -452,8 +442,7 @@ var _ = Describe("conditionManager", func() {
 			})
 
 			It("does not affect other conditions", func() {
-				newConditions, changed := manager.Finalize()
-				Expect(changed).To(BeTrue())
+				newConditions := manager.Finalize()
 
 				Expect(newConditions).To(ConsistOf(
 					Not(Equal(firstConditions[0])),
@@ -469,8 +458,7 @@ var _ = Describe("conditionManager", func() {
 			})
 
 			It("nothing is changed", func() {
-				newConditions, changed := manager.Finalize()
-				Expect(changed).To(BeFalse())
+				newConditions := manager.Finalize()
 
 				Expect(newConditions).To(ConsistOf(
 					Equal(firstConditions[0]),

--- a/pkg/conditions/conditionsfakes/fake_condition_manager.go
+++ b/pkg/conditions/conditionsfakes/fake_condition_manager.go
@@ -25,17 +25,15 @@ type FakeConditionManager struct {
 	addPositiveArgsForCall []struct {
 		arg1 v1.Condition
 	}
-	FinalizeStub        func() ([]v1.Condition, bool)
+	FinalizeStub        func() []v1.Condition
 	finalizeMutex       sync.RWMutex
 	finalizeArgsForCall []struct {
 	}
 	finalizeReturns struct {
 		result1 []v1.Condition
-		result2 bool
 	}
 	finalizeReturnsOnCall map[int]struct {
 		result1 []v1.Condition
-		result2 bool
 	}
 	IsSuccessfulStub        func() bool
 	isSuccessfulMutex       sync.RWMutex
@@ -148,7 +146,7 @@ func (fake *FakeConditionManager) AddPositiveArgsForCall(i int) v1.Condition {
 	return argsForCall.arg1
 }
 
-func (fake *FakeConditionManager) Finalize() ([]v1.Condition, bool) {
+func (fake *FakeConditionManager) Finalize() []v1.Condition {
 	fake.finalizeMutex.Lock()
 	ret, specificReturn := fake.finalizeReturnsOnCall[len(fake.finalizeArgsForCall)]
 	fake.finalizeArgsForCall = append(fake.finalizeArgsForCall, struct {
@@ -161,9 +159,9 @@ func (fake *FakeConditionManager) Finalize() ([]v1.Condition, bool) {
 		return stub()
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1
 }
 
 func (fake *FakeConditionManager) FinalizeCallCount() int {
@@ -172,36 +170,33 @@ func (fake *FakeConditionManager) FinalizeCallCount() int {
 	return len(fake.finalizeArgsForCall)
 }
 
-func (fake *FakeConditionManager) FinalizeCalls(stub func() ([]v1.Condition, bool)) {
+func (fake *FakeConditionManager) FinalizeCalls(stub func() []v1.Condition) {
 	fake.finalizeMutex.Lock()
 	defer fake.finalizeMutex.Unlock()
 	fake.FinalizeStub = stub
 }
 
-func (fake *FakeConditionManager) FinalizeReturns(result1 []v1.Condition, result2 bool) {
+func (fake *FakeConditionManager) FinalizeReturns(result1 []v1.Condition) {
 	fake.finalizeMutex.Lock()
 	defer fake.finalizeMutex.Unlock()
 	fake.FinalizeStub = nil
 	fake.finalizeReturns = struct {
 		result1 []v1.Condition
-		result2 bool
-	}{result1, result2}
+	}{result1}
 }
 
-func (fake *FakeConditionManager) FinalizeReturnsOnCall(i int, result1 []v1.Condition, result2 bool) {
+func (fake *FakeConditionManager) FinalizeReturnsOnCall(i int, result1 []v1.Condition) {
 	fake.finalizeMutex.Lock()
 	defer fake.finalizeMutex.Unlock()
 	fake.FinalizeStub = nil
 	if fake.finalizeReturnsOnCall == nil {
 		fake.finalizeReturnsOnCall = make(map[int]struct {
 			result1 []v1.Condition
-			result2 bool
 		})
 	}
 	fake.finalizeReturnsOnCall[i] = struct {
 		result1 []v1.Condition
-		result2 bool
-	}{result1, result2}
+	}{result1}
 }
 
 func (fake *FakeConditionManager) IsSuccessful() bool {

--- a/pkg/controller/deliverable/reconciler.go
+++ b/pkg/controller/deliverable/reconciler.go
@@ -111,18 +111,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 func (r *Reconciler) completeReconciliation(deliverable *v1alpha1.Deliverable, err error) (ctrl.Result, error) {
-	var changed bool
-	deliverable.Status.Conditions, changed = r.conditionManager.Finalize()
+	deliverable.Status.Conditions = r.conditionManager.Finalize()
 
-	var updateErr error
-	if changed || (deliverable.Status.ObservedGeneration != deliverable.Generation) {
-		deliverable.Status.ObservedGeneration = deliverable.Generation
-		updateErr = r.repo.StatusUpdate(deliverable)
-		if updateErr != nil {
-			r.logger.Error(updateErr, "update error")
-			if err == nil {
-				return ctrl.Result{}, fmt.Errorf("update deliverable status: %w", updateErr)
-			}
+	deliverable.Status.ObservedGeneration = deliverable.Generation
+	updateErr := r.repo.StatusUpdate(deliverable)
+	if updateErr != nil {
+		r.logger.Error(updateErr, "update error")
+		if err == nil {
+			return ctrl.Result{}, fmt.Errorf("update deliverable status: %w", updateErr)
 		}
 	}
 

--- a/pkg/controller/deliverable/reconciler_test.go
+++ b/pkg/controller/deliverable/reconciler_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Reconciler", func() {
 				},
 			}
 
-			conditionManager.FinalizeReturns(someConditions, true)
+			conditionManager.FinalizeReturns(someConditions)
 
 			_, _ = reconciler.Reconcile(ctx, req)
 

--- a/pkg/controller/delivery/reconciler.go
+++ b/pkg/controller/delivery/reconciler.go
@@ -86,7 +86,7 @@ func (r *Reconciler) reconcileDelivery(delivery *v1alpha1.ClusterDelivery) error
 }
 
 func (r *Reconciler) completeReconciliation(delivery *v1alpha1.ClusterDelivery, reconcileError error) (ctrl.Result, error) {
-	delivery.Status.Conditions, _ = r.conditionManager.Finalize()
+	delivery.Status.Conditions = r.conditionManager.Finalize()
 
 	delivery.Status.ObservedGeneration = delivery.Generation
 	err := r.repo.StatusUpdate(delivery)

--- a/pkg/controller/pipeline/reconciler.go
+++ b/pkg/controller/pipeline/reconciler.go
@@ -86,8 +86,8 @@ func (r *reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 	conditionManager := conditions.NewConditionManager(v1alpha1.PipelineReady, pipeline.Status.Conditions)
 	conditionManager.AddPositive(*condition)
-	//TODO: deal with changed (story #84)
-	pipeline.Status.Conditions, _ = conditionManager.Finalize()
+
+	pipeline.Status.Conditions = conditionManager.Finalize()
 	pipeline.Status.Outputs = outputs
 
 	statusUpdateError := r.repository.StatusUpdate(pipeline)

--- a/pkg/controller/supplychain/reconciler.go
+++ b/pkg/controller/supplychain/reconciler.go
@@ -77,19 +77,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 func (r *Reconciler) completeReconciliation(ctx context.Context, supplyChain *v1alpha1.ClusterSupplyChain, err error) (ctrl.Result, error) {
 	logger := logr.FromContext(ctx)
 
-	var changed bool
-	supplyChain.Status.Conditions, changed = r.conditionManager.Finalize()
+	supplyChain.Status.Conditions = r.conditionManager.Finalize()
 
-	var updateErr error
-	if changed || (supplyChain.Status.ObservedGeneration != supplyChain.Generation) {
-		supplyChain.Status.ObservedGeneration = supplyChain.Generation
-		updateErr = r.repo.StatusUpdate(supplyChain)
-		if updateErr != nil {
-			logger.Error(updateErr, "update error")
-			if err == nil {
-				logger.Info("finished")
-				return ctrl.Result{}, fmt.Errorf("update supply-chain status: %w", updateErr)
-			}
+	supplyChain.Status.ObservedGeneration = supplyChain.Generation
+	updateErr := r.repo.StatusUpdate(supplyChain)
+	if updateErr != nil {
+		logger.Error(updateErr, "update error")
+		if err == nil {
+			logger.Info("finished")
+			return ctrl.Result{}, fmt.Errorf("update supply-chain status: %w", updateErr)
 		}
 	}
 

--- a/pkg/controller/supplychain/reconciler_test.go
+++ b/pkg/controller/supplychain/reconciler_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Reconciler", func() {
 				Reason:             "Because I'm",
 				Message:            "Clap Along If you Feel",
 			}}
-			conditionManager.FinalizeReturns(expectedConditions, true)
+			conditionManager.FinalizeReturns(expectedConditions)
 
 			repo = &repositoryfakes.FakeRepository{}
 

--- a/pkg/controller/workload/reconciler.go
+++ b/pkg/controller/workload/reconciler.go
@@ -114,19 +114,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 func (r *Reconciler) completeReconciliation(ctx context.Context, workload *v1alpha1.Workload, err error) (ctrl.Result, error) {
 	logger := logr.FromContext(ctx)
 
-	var changed bool
-	workload.Status.Conditions, changed = r.conditionManager.Finalize()
+	workload.Status.Conditions = r.conditionManager.Finalize()
 
-	var updateErr error
-	if changed || (workload.Status.ObservedGeneration != workload.Generation) {
-		workload.Status.ObservedGeneration = workload.Generation
-		updateErr = r.repo.StatusUpdate(workload)
-		if updateErr != nil {
-			logger.Error(updateErr, "update error")
-			if err == nil {
-				logger.Info("finished")
-				return ctrl.Result{}, fmt.Errorf("update workload status: %w", updateErr)
-			}
+	workload.Status.ObservedGeneration = workload.Generation
+	updateErr := r.repo.StatusUpdate(workload)
+	if updateErr != nil {
+		logger.Error(updateErr, "update error")
+		if err == nil {
+			logger.Info("finished")
+			return ctrl.Result{}, fmt.Errorf("update workload status: %w", updateErr)
 		}
 	}
 

--- a/pkg/controller/workload/reconciler_test.go
+++ b/pkg/controller/workload/reconciler_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Reconciler", func() {
 				},
 			}
 
-			conditionManager.FinalizeReturns(someConditions, true)
+			conditionManager.FinalizeReturns(someConditions)
 
 			_, _ = reconciler.Reconcile(ctx, req)
 


### PR DESCRIPTION
Investigated why we still use changed:
* All our tests still work without it
* We introduced pkg/conditions/condition_manager.go#102-110
  which we believe ensures the status object emitted by finalize()
  is identical when nothing has changed.
* manually ensured that client.Status().Update() does not cause a
  resourceVersion bump when applying an identical status.

Co-authored-by: Emily Johnson <emjohnson@vmware.com>