### PR TITLE
hack: remove extra leading `v`

### DIFF
--- a/hack/publish-github-release.sh
+++ b/hack/publish-github-release.sh
@@ -31,7 +31,7 @@ main() {
 }
 
 submit_release_to_github() {
-        local version=v$1
+        local version=$1
 
         gh release create $version \
                 --draft \


### PR DESCRIPTION
before this fix, we had all of our github releases being submitted with an extra `v` (e.g., `vv0.0.7`)

/cc @pivotal-todd-ritchie @idoru 