### PR TITLE
bump tekton

### DIFF
--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -36,7 +36,7 @@ readonly KNATIVE_SERVING_VERSION=0.25.0
 readonly KPACK_VERSION=0.4.0
 readonly SECRETGEN_CONTROLLER_VERSION=0.5.0
 readonly SOURCE_CONTROLLER_VERSION=0.15.4
-readonly TEKTON_VERSION=0.28.0
+readonly TEKTON_VERSION=0.29.0
 
 main() {
         test $# -eq 0 && show_usage_help


### PR DESCRIPTION
we're currently not _yet_ using the carto.run/Pipeline resource in our
examples, but it's coming really soon, and tekton just released a new
version a couple days ago, so, let's just go ahead and bump it.

interesting yays imo:

1. > _promoting onerror to beta (`#4251`)_
2. > _supporting for single-quote bracket notation for params (`#4268`)
   > for instance, `$(params['<name>'])`

see https://github.com/tektoncd/pipeline/releases/tag/v0.29.0
