### PR TITLE
commit is not valid without updated 'generables'

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -35,6 +35,11 @@ jobs:
           make copyright
           [ -z "$(git status --porcelain)" ] || git diff HEAD --exit-code
 
+      - name: check all generables were regenerated and commited
+        run: |-
+          make gen-manifests gen-objects test-gen-manifests test-gen-objects generate
+          [ -z "$(git status --porcelain)" ] || git diff HEAD --exit-code
+
       - name: lint
         run: |-
           make lint


### PR DESCRIPTION
A commit should be rejected if any of the generables need to be updated, this includes

* fakes `make generate`
* crds `make gen-manifests`
* zz_deep_copy extensions `make gen-objects`
* test crds `make test-gen-manifests`
* test zz_deep_copy extensions `make test-gen-objects`

