### PR TITLE
Add a `make pre-push` target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,10 +77,14 @@ Maintainers should feel free to request authors to squash their branches. Mainta
 
 ### PR CI Actions
 
-Before a PR is accepted it will need to pass the validation checks. Authors can find a reasonable degree of of surety that they will pass by running `make test` and `make lint`. `make test` is only a subset of the checks that validation undertakes (for example, validation does an e2e test). If `make lint` fails, it might autocorrect your errors, but you will need to add the fixes to your commit.
+Before a PR is accepted it will need to pass the validation checks.
+
+Validations should pass if you can run `make test pre-push` without failing.
+
+If you run `make pre-push` and it fails, it usually autocorrects lints and generable files, so `git add` the changes,
+commit them and run `make pre-push` again.
 
 ---
-
 ## Running a local cluster
 
 A local Kubernetes cluster with a local registry and Cartographer installed can

--- a/Makefile
+++ b/Makefile
@@ -124,3 +124,18 @@ copyright:
 		-ignore site/static/\*\* \
 		-ignore site/themes/\*\* \
 		.
+
+.PHONY: pre-push .pre-push-check
+.pre-push-check: copyright lint gen-manifests gen-objects test-gen-manifests test-gen-objects generate
+
+# pre-push ensures that all generated content, copywrites and lints are
+# run and ends with an error if a mutation is caused.
+#
+# usage:
+#  1. with all your work added and committed (or stashed)
+#  2. run `make pre-push && git push`
+#  3. if any mutations occur, you can amend/rewrite or otherwise adjust your commits to include the changes
+pre-push:
+	[ -z "$$(git status --porcelain)" ] || (echo "not everything is committed, failing" && exit 1)
+	$(MAKE) .pre-push-check
+	[ -z "$$(git status --porcelain)" ] || (echo "changes occurred during pre-push check" && git diff HEAD --exit-code)


### PR DESCRIPTION
pre-push ensures that all generated content, copywrites and lints are
run and ends with an error if a mutation is caused.

usage:
  1. with all your work added and committed (or stashed)
  2. run `make pre-push && git push`
  3. if any mutations occur, you can amend/rewrite or otherwise adjust your commits to include the changes