### PR TITLE
example: match source-controller's duration unmarshalling

### DIFF
--- a/examples/source-to-knative-service/app-operator/supply-chain-templates.yaml
+++ b/examples/source-to-knative-service/app-operator/supply-chain-templates.yaml
@@ -36,7 +36,7 @@ spec:
     metadata:
       name: $(workload.metadata.name)$
     spec:
-      interval: 1m
+      interval: 1m0s
       url: $(workload.spec.source.git.url)$
       ref: $(workload.spec.source.git.ref)$
       gitImplementation: libgit2


### PR DESCRIPTION
as described in https://github.com/vmware-tanzu/cartographer/issues/95,
given that the unmarshalling that source-controller performs doesn't
match what we're trying to submit, we end up forcing reconciliation to
happen over and over again (better described in the issue).

now that we make use of informers rather than a 5s polling interval, the
issue becomes even more apparent.

ultimately we should figure out #95, so I'm a bit conflicted about even getting 
this in tbh,  but for now this fix prevents a big unnecessary reconciliation load
that will eventually be addressed.

Signed-off-by: Ciro S. Costa <ciroscosta@vmware.com>