### PR TITLE
hack: use double space in ytt checksum check

### DIFF
--- a/hack/ci/install-binaries.sh
+++ b/hack/ci/install-binaries.sh
@@ -54,7 +54,7 @@ install_ko() {
         local fname=ko_${KO_VERSION}_Linux_x86_64.tar.gz
 
         curl -sSOL $url
-        echo "${KO_CHECKSUM} $fname" | sha256sum -c
+        echo "${KO_CHECKSUM}  $fname" | sha256sum -c
         tar xzf $fname
 
         install -m 0755 ./ko /usr/local/bin
@@ -65,7 +65,7 @@ install_kubebuilder() {
         local fname=kubebuilder-tools-${KUBERNETES_VERSION}-linux-amd64.tar.gz
 
         curl -sSOL $url
-        echo "${KUBERNETES_CHECKSUM} $fname" | sha256sum -c
+        echo "${KUBERNETES_CHECKSUM}  $fname" | sha256sum -c
         tar xvzf $fname
 
         mv ./kubebuilder/bin/* /usr/local/bin
@@ -76,7 +76,7 @@ install_kuttl() {
         local fname=kubectl-kuttl_${KUTTL_VERSION}_linux_x86_64
 
         curl -sSOL $url
-        echo "${KUTTL_CHECKSUM} $fname" | sha256sum -c
+        echo "${KUTTL_CHECKSUM}  $fname" | sha256sum -c
 
         install -m 0755 $fname /usr/local/bin/kubectl-kuttl
 }
@@ -86,7 +86,7 @@ install_gh() {
         local fname=gh_${GH_VERSION}_linux_amd64.tar.gz
 
         curl -sSOL $url
-        echo "${GH_CHECKSUM} $fname" | sha256sum -c
+        echo "${GH_CHECKSUM}  $fname" | sha256sum -c
         tar xzf $fname --strip-components=1
 
         mv ./bin/gh /usr/local/bin

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -64,14 +64,14 @@ download_ytt_to_kodata() {
         local dest
         dest=$(realpath ./cmd/cartographer/kodata/$fname)
 
-        test -x $dest && echo "${YTT_CHECKSUM} $dest" | sha256sum -c && {
+        test -x $dest && echo "${YTT_CHECKSUM}  $dest" | sha256sum -c && {
                 echo "ytt already found in kodata."
                 return
         }
 
         pushd "$(mktemp -d)"
         curl -sSOL $url
-        echo "${YTT_CHECKSUM} $fname" | sha256sum -c
+        echo "${YTT_CHECKSUM}  $fname" | sha256sum -c
         install -m 0755 $fname $dest
         popd
 }


### PR DESCRIPTION
even though standard gnu coreutils accepts taking a single space as the
separator, that's not true for busybox.

by making sure we're passing a double space everywhere we compute a
checksum, we """guarantee""" to be good not only w/ gnu, but also
busybox-based ones (like alpine etc).

```c
				filename_ptr = strstr(line, "  ");          // double space
				/* handle format for binary checksums */
				if (filename_ptr == NULL) {
					filename_ptr = strstr(line, " *");
```

_(see https://github.com/mirror/busybox/blob/15f7d618ea7f8c3a0277c98309268b709e20d77c/coreutils/md5_sha1_sum.c#L296)_


ps.: in case you're wondering why this isn't captured by CI, it's because
we have github running based of ubuntu:

```yaml
jobs:
  build:
    runs-on: ubuntu-latest
``` 
