### PR TITLE
hack: make `docker_config` overwritable

### DIFF
--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -25,7 +25,7 @@ readonly REGISTRY=${REGISTRY:-"${HOST_ADDR}:${REGISTRY_PORT}"}
 readonly KIND_IMAGE=${KIND_IMAGE:-kindest/node:v1.21.1}
 readonly RELEASE_VERSION=${RELEASE_VERSION:-""}
 # shellcheck disable=SC2034  # This _should_ be marked as an extern but I clearly don't understand how it operates in github actions
-readonly DOCKER_CONFIG="/tmp/cartographer-docker"
+readonly DOCKER_CONFIG=${DOCKER_CONFIG:-"/tmp/cartographer-docker"}
 
 readonly REGISTRY_CONTAINER_NAME=cartographer-registry
 readonly KUBERNETES_CONTAINER_NAME=cartographer-control-plane


### PR DESCRIPTION
although the whole flow of installing / updating etc with _just_ `hack/setup.sh` works great as is, if someone has already configured a registry _outside_ `hack/setup.sh`, we end up not being able to install cartographer with something like `hack/setup.sh cartographer`. by making `DOCKER_CONFIG` configurable, we can have that set and then allow installation of cartographer making use of `hack/setup.sh`.

this way we're also more aligned with the other parameters where we provide defaults but allow overwrites