### PR TITLE
docs/examples: add runnable

### DIFF
--- a/examples/source-to-knative-service/app-operator/runtemplate-tekton-pipelinerun.yaml
+++ b/examples/source-to-knative-service/app-operator/runtemplate-tekton-pipelinerun.yaml
@@ -1,3 +1,17 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: carto.run/v1alpha1
 kind: ClusterRunTemplate
 metadata:

--- a/examples/source-to-knative-service/app-operator/runtemplate-tekton-pipelinerun.yaml
+++ b/examples/source-to-knative-service/app-operator/runtemplate-tekton-pipelinerun.yaml
@@ -1,0 +1,13 @@
+apiVersion: carto.run/v1alpha1
+kind: ClusterRunTemplate
+metadata:
+  name: tekton-pipelinerun
+spec:
+  template:
+    apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    metadata:
+      generateName: $(runnable.metadata.name)$-
+    spec:
+      taskRef: {name: $(selected.metadata.name)$}
+      params: $(runnable.spec.inputs.params)$

--- a/examples/source-to-knative-service/app-operator/supply-chain-templates.yaml
+++ b/examples/source-to-knative-service/app-operator/supply-chain-templates.yaml
@@ -46,6 +46,50 @@ spec:
 ---
 #
 #
+# `test` instantiates a Runnable object, responsible for submitting to
+# Kubernetes "pipeline invocation objects" (tekton's PipelineRun objects) that
+# run tests against the source code.
+#
+# Taking a `source` as input and passing that through as `output` if
+# successfull makes this template a gate that will effectively block a given
+# commit from moving forward in the supply chain in case tests fail.
+#
+#
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterSourceTemplate
+metadata:
+  name: test
+spec:
+  urlPath: .spec.inputs.source.url
+  revisionPath: .spec.inputs.source.revision
+
+  template:
+    apiVersion: carto.run/v1alpha1
+    kind: Runnable
+    metadata:
+      name: $(workload.metadata.name)$
+    spec:
+      runTemplateRef:
+        name: tekton-pipelinerun
+
+      selector:
+        resource:
+          apiVersion: tekton.dev/v1beta1
+          kind: Task
+        matchingLabels:
+          apps.tanzu.vmware.com/task: test
+
+      inputs:
+        source: $(source)$
+        params:
+          - name: blob-url
+            value: $(source.url)$
+
+
+---
+#
+#
 # `image` instantiates a `kpack/Image` object, responsible for ensuring that
 # there's a container image built and pushed to a container image registry
 # whenever there's either new source code, or its image builder gets na update.

--- a/examples/source-to-knative-service/app-operator/supply-chain.yaml
+++ b/examples/source-to-knative-service/app-operator/supply-chain.yaml
@@ -21,10 +21,10 @@ spec:
     app.tanzu.vmware.com/workload-type: web
 
   #
-  #
-  #   source-provider <--[src]-- image-builder <--[img]--- deployer
-  #     GitRepository               Image                    App
-  #
+  #     source-provider                   fluxcd/GitRepository
+  #       <--[src]-- source-tester        carto.run/Runnable --> tekton/TaskRun
+  #          <--[src]-- image-builder     kpack/Image
+  #             <--[img]-- deployer       kapp-ctrl/App
   #
   resources:
     - name: source-provider
@@ -32,12 +32,20 @@ spec:
         kind: ClusterSourceTemplate
         name: source
 
+    - name: source-tester
+      templateRef:
+        kind: ClusterSourceTemplate
+        name: test
+      sources:
+        - resource: source-provider
+          name: source
+
     - name: image-builder
       templateRef:
         kind: ClusterImageTemplate
         name: image
       sources:
-        - resource: source-provider
+        - resource: source-tester
           name: source
 
     - name: deployer

--- a/examples/source-to-knative-service/developer/tests-task.yaml
+++ b/examples/source-to-knative-service/developer/tests-task.yaml
@@ -1,3 +1,17 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:

--- a/examples/source-to-knative-service/developer/tests-task.yaml
+++ b/examples/source-to-knative-service/developer/tests-task.yaml
@@ -1,0 +1,21 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: test
+  labels:
+    apps.tanzu.vmware.com/task: test
+spec:
+  params:
+    - name: blob-url
+  steps:
+    - name: test
+      image: golang
+      command:
+        - bash
+        - -cxe
+        - |-
+          set -o pipefail
+
+          cd `mktemp -d`
+          curl -SL $(params.blob-url) | tar xvzf -
+          go test -v ./...

--- a/site/content/docs/reference.md
+++ b/site/content/docs/reference.md
@@ -438,10 +438,10 @@ spec:
   # (required)
   #
   inputs:
-    git-url: https://github.com/vmware-tanzu/cartographer
-    git-revision: f397a1f349146442c46051099d7e32ebaec79623
-
-    foo: [{bar: 123}]
+    serviceAccount: bla
+    params:
+       - name: foo
+         value: bar
 
 
   # reference to a ClusterRunTemplate that defines how objects should be

--- a/site/content/docs/reference.md
+++ b/site/content/docs/reference.md
@@ -514,15 +514,15 @@ spec:
   #
   # (required)
   #
-	template:
-		apiVersion: tekton.dev/v1beta1
-		kind: TaskRun
-		metadata:
-			generateName: $(runnable.metadata.name)$-
-		spec:
-			serviceAccountName: $(runnable.spec.inputs.serviceAccount)$
-			taskRef: $(runnable.spec.inputs.taskRef)$
-			params: $(runnable.spec.inputs.params)$
+  template:
+    apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    metadata:
+      generateName: $(runnable.metadata.name)$-
+    spec:
+      serviceAccountName: $(runnable.spec.inputs.serviceAccount)$
+      taskRef: $(runnable.spec.inputs.taskRef)$
+      params: $(runnable.spec.inputs.params)$
 ```
 
 It differs from supply chain templates in some aspects:

--- a/site/content/docs/reference.md
+++ b/site/content/docs/reference.md
@@ -31,10 +31,12 @@ Cartographer is composed of several custom resources, some of them being cluster
 - [`ClusterImageTemplate`](#clusterimagetemplate)
 - [`ClusterConfigTemplate`](#clusterconfigtemplate)
 - [`ClusterTemplate`](#clustertemplate)
+- [`ClusterRunTemplate`](#clusterruntemplate)
 
-and one that is namespace-scoped:
+and a couple namespace-scoped:
 
 - [`Workload`](#workload)
+- [`Runnable`](#runnable)
 
 
 ### Workload
@@ -73,7 +75,7 @@ spec:
   #
   serviceClaims:
     - name: broker
-      ref: 
+      ref:
         apiVersion: services.tanzu.vmware.com/v1alpha1
         kind: RabbitMQ
         name: rabbit-broker
@@ -114,7 +116,7 @@ notes:
 
 1. labels serve as a way of indirectly selecting `ClusterSupplyChain` - `Workload`s without labels that match a `ClusterSupplyChain`'s `spec.selector` won't be reconciled and will stay in an `Errored` state.
 
-2. `spec.image` is useful for enabling workflows that are not based on building the container image from within the supplychain, but outside. 
+2. `spec.image` is useful for enabling workflows that are not based on building the container image from within the supplychain, but outside.
 
 _ref: [pkg/apis/v1alpha1/workload.go](../../../pkg/apis/v1alpha1/workload.go)_
 
@@ -125,7 +127,7 @@ With a `ClusterSupplyChain`, app operators describe which "shape of applications
 
 Those `Workload`s that match `spec.selector` then go through the resources specified in `spec.resources`.
 
-A resource can emit values, which the supply chain can make available to other resources. 
+A resource can emit values, which the supply chain can make available to other resources.
 
 ```yaml
 apiVersion: carto.run/v1alpha1
@@ -162,8 +164,8 @@ spec:
 
       # a set of resources that provide source information, that is, url and
       # revision.
-      # 
-      # in a template, these can be consumed as: 
+      #
+      # in a template, these can be consumed as:
       #
       #    $(sources.<name>.url)$
       #    $(sources.<name>.revision)$
@@ -250,7 +252,7 @@ spec:
       # name of the parameter (required, unique in this list)
       #
     - name: git-implementation
-      # default value if not specified in the resource that references 
+      # default value if not specified in the resource that references
       # this templateClusterSupplyChain (required)
       #
       default: libgit2
@@ -260,7 +262,7 @@ spec:
   #
   urlPath: .status.artifact.url
 
-  # jsonpath expression to instruct where in the object templated out 
+  # jsonpath expression to instruct where in the object templated out
   # source code revision information can be found. (required)
   #
   revisionPath: .status.artifact.revision
@@ -310,7 +312,7 @@ spec:
   #
   params: []
 
-  # jsonpath expression to instruct where in the object templated out container 
+  # jsonpath expression to instruct where in the object templated out container
   # image information can be found. (required)
   #
   imagePath: .status.latestImage
@@ -335,6 +337,7 @@ spec:
 ```
 
 _ref: [pkg/apis/v1alpha1/cluster_image_template.go](../../../pkg/apis/v1alpha1/cluster_image_template.go)_
+
 
 ### ClusterConfigTemplate
 
@@ -408,3 +411,140 @@ spec:
 ```
 
 _ref: [pkg/apis/v1alpha1/cluster_template.go](../../../pkg/apis/v1alpha1/cluster_template.go)_
+
+
+### Runnable
+
+A `Runnable` object declares the intention of having immutable objects
+submitted to Kubernetes according to a template (via ClusterRunTemplate)
+whenever any of the inputs passed to it changes. i.e., it allows us to provide
+a mutable spec that drives the creation of immutable objects whenever that spec
+changes.
+
+
+```yaml
+apiVersion: carto.run/v1alpha1
+kind: Runnable
+metadata:
+  name: test-runner
+spec:
+  # data to be made available to the template of ClusterRunTemplate
+  # that we point at.
+  #
+  # this field takes as value an object that maps strings to values of any
+  # kind, which can then be reference in a template using jsonpath such as
+  # `$(runnable.spec.inputs.<key...>)$`.
+  #
+  # (required)
+  #
+  inputs:
+    git-url: https://github.com/vmware-tanzu/cartographer
+    git-revision: f397a1f349146442c46051099d7e32ebaec79623
+
+    foo: [{bar: 123}]
+
+
+  # reference to a ClusterRunTemplate that defines how objects should be
+  # created referencing the data passed to the Runnable.
+  #
+  # (required)
+  #
+  runTemplateRef:
+    name: job-runner
+
+
+  # an optional selection rule for finding an object that should be used
+  # together with the one being stamped out by the runnable.
+  #
+  # an object found using the rules described here are made available during
+  # interpolation time via `$(selected.<...object>)$`.
+  #
+  # (optional)
+  #
+  selector:
+    resource:
+      kind: Pipeline
+      apiVersion: tekton.dev/v1beta1
+    matchingLabels:
+      pipelines.foo.bar: testing
+```
+
+
+### ClusterRunTemplate
+
+A `ClusterRunTemplate` defines how an immutable object should be stamped out
+based on data provided by a `Runnable`.
+
+```yaml
+apiVersion: carto.run/v1alpha1
+kind: ClusterRunTemplate
+metadata:
+  name: image-builder
+spec:
+  # data to be gathered from the objects that it interpolates once they #
+  # succeeded (based on the object presenting a condition with type 'Succeeded'
+  # and status `True`).
+  #
+  # (optional)
+  #
+  outputs:
+    # e.g., make available under the Runnable `outputs` section in `status` a
+    # field called "latestImage" that exposes the result named 'IMAGE-DIGEST'
+    # of a tekton task that builds a container image.
+    #
+    latestImage: .status.results[?(@.name=="IMAGE-DIGEST")].value
+
+
+  # definition of the object to interpolate and submit to kubernetes.
+  #
+  # data available for interpolation:
+  #   - `runnable`: the Runnable object that referenced this template.
+  #
+  #                 e.g.:  params:
+  #                        - name: revison
+  #                          value: $(runnable.spec.inputs.git-revision)$
+  #
+  #
+  #   - `selected`: a related object that got selected using the Runnable
+  #                 selector query.
+  #
+  #                 e.g.:  taskRef:
+  #                          name: $(selected.metadata.name)$
+  #                          namespace: $(selected.metadata.namespace)$
+  #
+  # (required)
+  #
+	template:
+		apiVersion: tekton.dev/v1beta1
+		kind: TaskRun
+		metadata:
+			generateName: $(runnable.metadata.name)$-
+		spec:
+			serviceAccountName: $(runnable.spec.inputs.serviceAccount)$
+			taskRef: $(runnable.spec.inputs.taskRef)$
+			params: $(runnable.spec.inputs.params)$
+```
+
+It differs from supply chain templates in some aspects:
+
+- it cannot be referenced directly by a ClusterSupplyChain object (it can only
+  be reference by a Runnable)
+
+- `outputs` provide a free-form way of exposing any form of results from what
+  has been run (i.e., submitted by the Runnable) to the status of the Runnable
+  object (as opposed to typed "source", "image", and "config" from supply
+  chains)
+
+- templating context (values provided to the interpolation) is specific to the
+  Runnable: the runnable object itself and the object resulting from the
+  selection query.
+
+- templated object metadata.name should not be set. differently from
+  ClusterSupplyChain, a Runnable has the semantics of creating new objects on
+  change, rather than patching. This means that on every input set change, a new
+  name must be derived. To be sure that a name can always be generated,
+  `metadata.generateName` should be set rather than `metadata.name`.
+
+Similarly to other templates, it has a `template` field where data is taken (in
+this case, from Runnable and selected objects via `runnable.spec.selector`) and
+via `$()$` allows one to interpolate such data to form a final object.


### PR DESCRIPTION
hey folks,

it's been long overdue having Runnable and ClusterRunTemplate documented and
part of the example, benefitting us not only in terms of having docs, but also
ensuring that in an e2e we don't regress as the example is ran on every commit.

please let me know if you believe there's a better way that we could frame those
resources and/or anything else that we could improve here.

thanks!

closes #287

## Changes proposed by this PR

- docs: add two entries to the `reference` page
    - runnable
    - clusterruntemplate

- examples: update the e2e to include a test before building an image
    - now: `source-provider <- source-tester <- image-builder <- deployer`


## Release Note

Add example and documentation of Runnable and ClusterRunTemplate.


## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
