### PR TITLE
repository: use "best match" for supplychain/delivery selection

### DIFF
--- a/pkg/apis/v1alpha1/cluster_delivery.go
+++ b/pkg/apis/v1alpha1/cluster_delivery.go
@@ -47,6 +47,10 @@ type ClusterDelivery struct {
 	Status            ClusterDeliveryStatus `json:"status,omitempty"`
 }
 
+func (c *ClusterDelivery) GetSelector() map[string]string {
+	return c.Spec.Selector
+}
+
 type ClusterDeliverySpec struct {
 	Resources []ClusterDeliveryResource `json:"resources"`
 	Selector  map[string]string         `json:"selector"`

--- a/pkg/apis/v1alpha1/cluster_supply_chain.go
+++ b/pkg/apis/v1alpha1/cluster_supply_chain.go
@@ -134,6 +134,10 @@ func (c *ClusterSupplyChain) ValidateDelete() error {
 	return nil
 }
 
+func (c *ClusterSupplyChain) GetSelector() map[string]string {
+	return c.Spec.Selector
+}
+
 func GetSelectorsFromObject(o client.Object) []string {
 	var res []string
 	res = []string{}

--- a/pkg/controller/deliverable/reconciler.go
+++ b/pkg/controller/deliverable/reconciler.go
@@ -219,12 +219,12 @@ func (r *Reconciler) getDeliveriesForDeliverable(ctx context.Context, deliverabl
 			deliverable.Namespace, deliverable.Name, getDeliveryNames(deliveries))
 	}
 
-	delivery := &deliveries[0]
+	delivery := deliveries[0]
 	log.V(logger.DEBUG).Info("delivery matched for deliverable", "delivery", delivery.Name)
 	return delivery, nil
 }
 
-func getDeliveryNames(objs []v1alpha1.ClusterDelivery) []string {
+func getDeliveryNames(objs []*v1alpha1.ClusterDelivery) []string {
 	var names []string
 	for _, obj := range objs {
 		names = append(names, obj.GetName())

--- a/pkg/controller/deliverable/reconciler_test.go
+++ b/pkg/controller/deliverable/reconciler_test.go
@@ -197,7 +197,7 @@ var _ = Describe("Reconciler", func() {
 					},
 				},
 			}
-			repo.GetDeliveriesForDeliverableReturns([]v1alpha1.ClusterDelivery{delivery}, nil)
+			repo.GetDeliveriesForDeliverableReturns([]*v1alpha1.ClusterDelivery{&delivery}, nil)
 			stampedObject1 = &unstructured.Unstructured{}
 			stampedObject1.SetGroupVersionKind(schema.GroupVersionKind{
 				Group:   "thing.io",
@@ -270,7 +270,7 @@ var _ = Describe("Reconciler", func() {
 						Message: "some informative message",
 					},
 				}
-				repo.GetDeliveriesForDeliverableReturns([]v1alpha1.ClusterDelivery{delivery}, nil)
+				repo.GetDeliveriesForDeliverableReturns([]*v1alpha1.ClusterDelivery{&delivery}, nil)
 			})
 
 			It("does not return an error", func() {
@@ -640,7 +640,7 @@ var _ = Describe("Reconciler", func() {
 				Version: "alphabeta1",
 				Kind:    "MyThing",
 			})
-			repo.GetDeliveriesForDeliverableReturns([]v1alpha1.ClusterDelivery{delivery, delivery}, nil)
+			repo.GetDeliveriesForDeliverableReturns([]*v1alpha1.ClusterDelivery{&delivery, &delivery}, nil)
 		})
 
 		It("does not return an error", func() {

--- a/pkg/controller/workload/reconciler.go
+++ b/pkg/controller/workload/reconciler.go
@@ -172,5 +172,5 @@ func (r *Reconciler) getSupplyChainsForWorkload(ctx context.Context, workload *v
 		return nil, fmt.Errorf("too many supply chains match the workload selector")
 	}
 
-	return &supplyChains[0], nil
+	return supplyChains[0], nil
 }

--- a/pkg/controller/workload/reconciler_test.go
+++ b/pkg/controller/workload/reconciler_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Reconciler", func() {
 					},
 				},
 			}
-			repo.GetSupplyChainsForWorkloadReturns([]v1alpha1.ClusterSupplyChain{supplyChain}, nil)
+			repo.GetSupplyChainsForWorkloadReturns([]*v1alpha1.ClusterSupplyChain{&supplyChain}, nil)
 			stampedObject1 = &unstructured.Unstructured{}
 			stampedObject1.SetGroupVersionKind(schema.GroupVersionKind{
 				Group:   "thing.io",
@@ -266,7 +266,7 @@ var _ = Describe("Reconciler", func() {
 						Message: "some informative message",
 					},
 				}
-				repo.GetSupplyChainsForWorkloadReturns([]v1alpha1.ClusterSupplyChain{supplyChain}, nil)
+				repo.GetSupplyChainsForWorkloadReturns([]*v1alpha1.ClusterSupplyChain{&supplyChain}, nil)
 			})
 
 			It("does not return an error", func() {
@@ -503,7 +503,7 @@ var _ = Describe("Reconciler", func() {
 	Context("and the repo returns multiple supply chains", func() {
 		BeforeEach(func() {
 			supplyChain := v1alpha1.ClusterSupplyChain{}
-			repo.GetSupplyChainsForWorkloadReturns([]v1alpha1.ClusterSupplyChain{supplyChain, supplyChain}, nil)
+			repo.GetSupplyChainsForWorkloadReturns([]*v1alpha1.ClusterSupplyChain{&supplyChain, &supplyChain}, nil)
 		})
 
 		It("calls the condition manager to report too mane supply chains matched", func() {

--- a/pkg/repository/label_matcher.go
+++ b/pkg/repository/label_matcher.go
@@ -1,0 +1,115 @@
+// Copyright 2021 VMware
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repository
+
+type SelectorGetter interface {
+	GetSelector() map[string]string
+}
+
+type LabelsGetter interface {
+	GetLabels() map[string]string
+}
+
+// BestLabelMatch attempts at finding the targets that best match the label set
+// of the source.
+//
+func BestLabelMatches(source LabelsGetter, targets []SelectorGetter) []SelectorGetter {
+	if len(targets) == 0 {
+		return nil
+	}
+
+	// count the number of matches
+	matchCounter := make([]int, len(targets))
+	for idx, target := range targets {
+		if !subsetOf(source.GetLabels(), target.GetSelector()) {
+			continue
+		}
+
+		for key, value := range target.GetSelector() {
+			srcValue, found := source.GetLabels()[key]
+			if !found || srcValue != value {
+				continue
+			}
+
+			matchCounter[idx] += 1
+		}
+	}
+
+	// keep just those that have the highest amount of matches
+	var selectors []SelectorGetter
+	if highestMatch := maxSlice(matchCounter); highestMatch > 0 {
+		for idx := range matchCounter {
+			if matchCounter[idx] == highestMatch {
+				selectors = append(selectors, targets[idx])
+			}
+		}
+	}
+
+	// filter down to the most specific set
+	selectorsCount := make([]int, len(selectors))
+	for idx, selector := range selectors {
+		selectorsCount[idx] = len(selector.GetSelector())
+	}
+
+	var res []SelectorGetter
+	minSelectorCount := minSlice(selectorsCount)
+	for _, selector := range selectors {
+		if len(selector.GetSelector()) == minSelectorCount {
+			res = append(res, selector)
+		}
+	}
+
+	return res
+}
+
+// minSlice gets the minimum value in a given slice (or 999, otherwise)
+//
+func minSlice(slice []int) int {
+	min := 999
+
+	for idx, element := range slice {
+		if idx == 0 || element < min {
+			min = element
+		}
+	}
+
+	return min
+}
+
+// maxSlice gets the maximum value in a given slice (or 0, otherwise)
+//
+func maxSlice(slice []int) int {
+	max := 0
+
+	for idx, element := range slice {
+		if idx == 0 || element > max {
+			max = element
+		}
+	}
+
+	return max
+}
+
+// subsetOf verifies whether `a` is a subset of `b`
+//
+func subsetOf(a, b map[string]string) bool {
+	for key, value := range b {
+		if a[key] != value {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/repository/label_matcher_test.go
+++ b/pkg/repository/label_matcher_test.go
@@ -1,0 +1,212 @@
+// Copyright 2021 VMware
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repository_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/vmware-tanzu/cartographer/pkg/apis/v1alpha1"
+	"github.com/vmware-tanzu/cartographer/pkg/repository"
+)
+
+var _ = Describe("BestLabelMatches", func() {
+
+	type testcase struct {
+		source   repository.LabelsGetter
+		targets  []repository.SelectorGetter
+		expected []repository.SelectorGetter
+	}
+
+	type labels map[string]string
+
+	var lg = func(labelset labels) repository.LabelsGetter {
+		return &v1alpha1.Workload{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: labelset,
+			},
+		}
+	}
+
+	var sg = func(labelset labels) repository.SelectorGetter {
+		return &v1alpha1.ClusterSupplyChain{
+			Spec: v1alpha1.SupplyChainSpec{
+				Selector: labelset,
+			},
+		}
+	}
+
+	DescribeTable("cases",
+		func(tc testcase) {
+			actual := repository.BestLabelMatches(
+				tc.source, tc.targets,
+			)
+
+			if tc.expected == nil {
+				Expect(actual).To(BeNil())
+				return
+			}
+
+			Expect(actual).To(Equal(tc.expected))
+		},
+
+		Entry("empty targets", testcase{
+			source:   lg(labels{"foo": "bar"}),
+			expected: nil,
+		}),
+
+		Entry("complete mismatched src & targets", testcase{
+			source: lg(labels{
+				"type": "web",
+			}),
+			targets: []repository.SelectorGetter{
+				sg(labels{
+					"----": "----",
+				}),
+			},
+			expected: nil,
+		}),
+
+		Entry("partial match; target with less labels than source", testcase{
+			source: lg(labels{
+				"type": "web",
+				"test": "tekton",
+			}),
+			targets: []repository.SelectorGetter{
+				sg(labels{
+					"type": "web",
+				}),
+			},
+			expected: []repository.SelectorGetter{
+				sg(labels{
+					"type": "web",
+				}),
+			},
+		}),
+
+		Entry("partial match; source with less labels than target", testcase{
+			source: lg(labels{
+				"type": "web",
+			}),
+			targets: []repository.SelectorGetter{
+				sg(labels{
+					"type": "web",
+					"test": "tekton",
+				}),
+			},
+			expected: nil,
+		}),
+
+		Entry("absolute match", testcase{
+			source: lg(labels{
+				"type": "web",
+				"test": "tekton",
+			}),
+			targets: []repository.SelectorGetter{
+				sg(labels{
+					"type": "web",
+					"test": "----",
+				}),
+				sg(labels{ // ! this
+					"type": "web",
+					"test": "tekton",
+				}),
+				sg(labels{
+					"type": "mobile",
+					"test": "----",
+				}),
+			},
+			expected: []repository.SelectorGetter{
+				sg(labels{
+					"type": "web",
+					"test": "tekton",
+				}),
+			},
+		}),
+
+		Entry("exact partial match", testcase{
+			source: lg(labels{
+				"type":  "web",
+				"test":  "tekton",
+				"scan":  "security",
+				"input": "image",
+			}),
+			targets: []repository.SelectorGetter{
+				sg(labels{
+					"type": "----",
+					"test": "tekton",
+					"scan": "----",
+				}),
+				sg(labels{ // ! this
+					"type": "web",
+					"test": "tekton",
+					"scan": "security",
+				}),
+				sg(labels{ // ! this
+					"type":  "web",
+					"test":  "tekton",
+					"input": "image",
+				}),
+			},
+			expected: []repository.SelectorGetter{
+				sg(labels{
+					"type": "web",
+					"test": "tekton",
+					"scan": "security",
+				}),
+				sg(labels{
+					"type":  "web",
+					"test":  "tekton",
+					"input": "image",
+				}),
+			},
+		}),
+
+		Entry("exact match with no extras", testcase{
+			source: lg(labels{
+				"type": "web",
+				"test": "tekton",
+				"scan": "security",
+			}),
+			targets: []repository.SelectorGetter{
+				sg(labels{
+					"type": "----",
+					"test": "tekton",
+					"scan": "----",
+				}),
+				sg(labels{ // ! this
+					"type": "web",
+					"test": "tekton",
+					"scan": "security",
+				}),
+				sg(labels{
+					"type":  "web",
+					"test":  "tekton",
+					"scan":  "security",
+					"input": "image",
+				}),
+			},
+			expected: []repository.SelectorGetter{
+				sg(labels{
+					"type": "web",
+					"test": "tekton",
+					"scan": "security",
+				}),
+			},
+		}),
+	)
+})

--- a/pkg/repository/repositoryfakes/fake_repository.go
+++ b/pkg/repository/repositoryfakes/fake_repository.go
@@ -55,18 +55,18 @@ type FakeRepository struct {
 		result1 *v1alpha1.Deliverable
 		result2 error
 	}
-	GetDeliveriesForDeliverableStub        func(context.Context, *v1alpha1.Deliverable) ([]v1alpha1.ClusterDelivery, error)
+	GetDeliveriesForDeliverableStub        func(context.Context, *v1alpha1.Deliverable) ([]*v1alpha1.ClusterDelivery, error)
 	getDeliveriesForDeliverableMutex       sync.RWMutex
 	getDeliveriesForDeliverableArgsForCall []struct {
 		arg1 context.Context
 		arg2 *v1alpha1.Deliverable
 	}
 	getDeliveriesForDeliverableReturns struct {
-		result1 []v1alpha1.ClusterDelivery
+		result1 []*v1alpha1.ClusterDelivery
 		result2 error
 	}
 	getDeliveriesForDeliverableReturnsOnCall map[int]struct {
-		result1 []v1alpha1.ClusterDelivery
+		result1 []*v1alpha1.ClusterDelivery
 		result2 error
 	}
 	GetDeliveryStub        func(context.Context, string) (*v1alpha1.ClusterDelivery, error)
@@ -150,18 +150,18 @@ type FakeRepository struct {
 		result1 *v1alpha1.ClusterSupplyChain
 		result2 error
 	}
-	GetSupplyChainsForWorkloadStub        func(context.Context, *v1alpha1.Workload) ([]v1alpha1.ClusterSupplyChain, error)
+	GetSupplyChainsForWorkloadStub        func(context.Context, *v1alpha1.Workload) ([]*v1alpha1.ClusterSupplyChain, error)
 	getSupplyChainsForWorkloadMutex       sync.RWMutex
 	getSupplyChainsForWorkloadArgsForCall []struct {
 		arg1 context.Context
 		arg2 *v1alpha1.Workload
 	}
 	getSupplyChainsForWorkloadReturns struct {
-		result1 []v1alpha1.ClusterSupplyChain
+		result1 []*v1alpha1.ClusterSupplyChain
 		result2 error
 	}
 	getSupplyChainsForWorkloadReturnsOnCall map[int]struct {
-		result1 []v1alpha1.ClusterSupplyChain
+		result1 []*v1alpha1.ClusterSupplyChain
 		result2 error
 	}
 	GetWorkloadStub        func(context.Context, string, string) (*v1alpha1.Workload, error)
@@ -403,7 +403,7 @@ func (fake *FakeRepository) GetDeliverableReturnsOnCall(i int, result1 *v1alpha1
 	}{result1, result2}
 }
 
-func (fake *FakeRepository) GetDeliveriesForDeliverable(arg1 context.Context, arg2 *v1alpha1.Deliverable) ([]v1alpha1.ClusterDelivery, error) {
+func (fake *FakeRepository) GetDeliveriesForDeliverable(arg1 context.Context, arg2 *v1alpha1.Deliverable) ([]*v1alpha1.ClusterDelivery, error) {
 	fake.getDeliveriesForDeliverableMutex.Lock()
 	ret, specificReturn := fake.getDeliveriesForDeliverableReturnsOnCall[len(fake.getDeliveriesForDeliverableArgsForCall)]
 	fake.getDeliveriesForDeliverableArgsForCall = append(fake.getDeliveriesForDeliverableArgsForCall, struct {
@@ -429,7 +429,7 @@ func (fake *FakeRepository) GetDeliveriesForDeliverableCallCount() int {
 	return len(fake.getDeliveriesForDeliverableArgsForCall)
 }
 
-func (fake *FakeRepository) GetDeliveriesForDeliverableCalls(stub func(context.Context, *v1alpha1.Deliverable) ([]v1alpha1.ClusterDelivery, error)) {
+func (fake *FakeRepository) GetDeliveriesForDeliverableCalls(stub func(context.Context, *v1alpha1.Deliverable) ([]*v1alpha1.ClusterDelivery, error)) {
 	fake.getDeliveriesForDeliverableMutex.Lock()
 	defer fake.getDeliveriesForDeliverableMutex.Unlock()
 	fake.GetDeliveriesForDeliverableStub = stub
@@ -442,28 +442,28 @@ func (fake *FakeRepository) GetDeliveriesForDeliverableArgsForCall(i int) (conte
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeRepository) GetDeliveriesForDeliverableReturns(result1 []v1alpha1.ClusterDelivery, result2 error) {
+func (fake *FakeRepository) GetDeliveriesForDeliverableReturns(result1 []*v1alpha1.ClusterDelivery, result2 error) {
 	fake.getDeliveriesForDeliverableMutex.Lock()
 	defer fake.getDeliveriesForDeliverableMutex.Unlock()
 	fake.GetDeliveriesForDeliverableStub = nil
 	fake.getDeliveriesForDeliverableReturns = struct {
-		result1 []v1alpha1.ClusterDelivery
+		result1 []*v1alpha1.ClusterDelivery
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeRepository) GetDeliveriesForDeliverableReturnsOnCall(i int, result1 []v1alpha1.ClusterDelivery, result2 error) {
+func (fake *FakeRepository) GetDeliveriesForDeliverableReturnsOnCall(i int, result1 []*v1alpha1.ClusterDelivery, result2 error) {
 	fake.getDeliveriesForDeliverableMutex.Lock()
 	defer fake.getDeliveriesForDeliverableMutex.Unlock()
 	fake.GetDeliveriesForDeliverableStub = nil
 	if fake.getDeliveriesForDeliverableReturnsOnCall == nil {
 		fake.getDeliveriesForDeliverableReturnsOnCall = make(map[int]struct {
-			result1 []v1alpha1.ClusterDelivery
+			result1 []*v1alpha1.ClusterDelivery
 			result2 error
 		})
 	}
 	fake.getDeliveriesForDeliverableReturnsOnCall[i] = struct {
-		result1 []v1alpha1.ClusterDelivery
+		result1 []*v1alpha1.ClusterDelivery
 		result2 error
 	}{result1, result2}
 }
@@ -847,7 +847,7 @@ func (fake *FakeRepository) GetSupplyChainReturnsOnCall(i int, result1 *v1alpha1
 	}{result1, result2}
 }
 
-func (fake *FakeRepository) GetSupplyChainsForWorkload(arg1 context.Context, arg2 *v1alpha1.Workload) ([]v1alpha1.ClusterSupplyChain, error) {
+func (fake *FakeRepository) GetSupplyChainsForWorkload(arg1 context.Context, arg2 *v1alpha1.Workload) ([]*v1alpha1.ClusterSupplyChain, error) {
 	fake.getSupplyChainsForWorkloadMutex.Lock()
 	ret, specificReturn := fake.getSupplyChainsForWorkloadReturnsOnCall[len(fake.getSupplyChainsForWorkloadArgsForCall)]
 	fake.getSupplyChainsForWorkloadArgsForCall = append(fake.getSupplyChainsForWorkloadArgsForCall, struct {
@@ -873,7 +873,7 @@ func (fake *FakeRepository) GetSupplyChainsForWorkloadCallCount() int {
 	return len(fake.getSupplyChainsForWorkloadArgsForCall)
 }
 
-func (fake *FakeRepository) GetSupplyChainsForWorkloadCalls(stub func(context.Context, *v1alpha1.Workload) ([]v1alpha1.ClusterSupplyChain, error)) {
+func (fake *FakeRepository) GetSupplyChainsForWorkloadCalls(stub func(context.Context, *v1alpha1.Workload) ([]*v1alpha1.ClusterSupplyChain, error)) {
 	fake.getSupplyChainsForWorkloadMutex.Lock()
 	defer fake.getSupplyChainsForWorkloadMutex.Unlock()
 	fake.GetSupplyChainsForWorkloadStub = stub
@@ -886,28 +886,28 @@ func (fake *FakeRepository) GetSupplyChainsForWorkloadArgsForCall(i int) (contex
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeRepository) GetSupplyChainsForWorkloadReturns(result1 []v1alpha1.ClusterSupplyChain, result2 error) {
+func (fake *FakeRepository) GetSupplyChainsForWorkloadReturns(result1 []*v1alpha1.ClusterSupplyChain, result2 error) {
 	fake.getSupplyChainsForWorkloadMutex.Lock()
 	defer fake.getSupplyChainsForWorkloadMutex.Unlock()
 	fake.GetSupplyChainsForWorkloadStub = nil
 	fake.getSupplyChainsForWorkloadReturns = struct {
-		result1 []v1alpha1.ClusterSupplyChain
+		result1 []*v1alpha1.ClusterSupplyChain
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeRepository) GetSupplyChainsForWorkloadReturnsOnCall(i int, result1 []v1alpha1.ClusterSupplyChain, result2 error) {
+func (fake *FakeRepository) GetSupplyChainsForWorkloadReturnsOnCall(i int, result1 []*v1alpha1.ClusterSupplyChain, result2 error) {
 	fake.getSupplyChainsForWorkloadMutex.Lock()
 	defer fake.getSupplyChainsForWorkloadMutex.Unlock()
 	fake.GetSupplyChainsForWorkloadStub = nil
 	if fake.getSupplyChainsForWorkloadReturnsOnCall == nil {
 		fake.getSupplyChainsForWorkloadReturnsOnCall = make(map[int]struct {
-			result1 []v1alpha1.ClusterSupplyChain
+			result1 []*v1alpha1.ClusterSupplyChain
 			result2 error
 		})
 	}
 	fake.getSupplyChainsForWorkloadReturnsOnCall[i] = struct {
-		result1 []v1alpha1.ClusterSupplyChain
+		result1 []*v1alpha1.ClusterSupplyChain
 		result2 error
 	}{result1, result2}
 }


### PR DESCRIPTION
## Changes proposed by this PR

1. implement a function (`BestLabelMatches`) that, given something with labels and a set of objects that have selectors, gives the subset of the latter that "best matches" that initial label set according to [RFC-0015].

2. make use of such function for both delivery and workload

[RFC-0015]: https://github.com/vmware-tanzu/cartographer/pull/319

closes #298 

## Release Note

Allow users to have their Workload and Deliverables selecting ClusterSupplyChain and ClusterDelivery (accordingly) based on multiple labels rather than exact match.


## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [ ] Removed non-atomic or `wip` commits
- [ ] Filled in the [Release Note](#Release-Note) section above
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
