### PR TITLE
repository: revert resourceVersion removal

### DIFF
--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -194,6 +194,8 @@ func (r *repository) createUnstructured(ctx context.Context, obj *unstructured.U
 
 func (r *repository) patchUnstructured(ctx context.Context, existingObj *unstructured.Unstructured, obj *unstructured.Unstructured) error {
 	submitted := obj.DeepCopy()
+
+	obj.SetResourceVersion(existingObj.GetResourceVersion())
 	if err := r.cl.Patch(ctx, obj, client.MergeFrom(existingObj)); err != nil {
 		return fmt.Errorf("patch: %w", err)
 	}


### PR DESCRIPTION

## Changes proposed by this PR

- go back to setting `metadata.resourceVersion` for the objects we patch

## Context

we had a regression after getting https://github.com/vmware-tanzu/cartographer/pull/357 in, which coupled with the use of informers for everything, made this less obvious (unless you had actual changes, just running the example here wouldn't surface it as we PATCH much less now).

to reproduce:

1. submit the example in this repository, see that it's all good in the hood
2. either stop the reconciler and then bring it back up, or update the workload object

```
{"level":"error","ts":1637266420.3760583,"logger":"controller.workload","msg":"Reconciler error","name":"dev","namespace":"default","error":"unable to apply object 'default/dev': patch: gitrepositories.source.toolkit.fluxcd.
io \"dev\" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/home/cirocosta/go/pkg
/mod/sigs.k8s.io/controller-runtime@v0.10.3/pkg/internal/controller/controller.go:227"}
```


I thought we didn’t need it for PATCH ops, but, given the diff that we perform, we apparently end up needing it (otherwise, we send a diff that's not appreciated by kube-apiserver):


```
> sigs.k8s.io/controller-runtime/pkg/client.(*unstructuredClient).Patch() /home/cirocosta/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.3/pkg/client/unstructured_client.go:155 (PC: 0x191effa)
   150:         if err != nil {
   151:                 return err
   152:         }
   153:
   154:         data, err := patch.Data(obj)
=> 155:         if err != nil {
   156:                 return err
   157:         }
   158:
   159:         patchOpts := &PatchOptions{}
   160:         return o.Patch(patch.Type()).
```

in the moment of performing the PATCH on something that would have no updates, we see

```
"{\"metadata\":{\"creationTimestamp\":null,\"finalizers\":null,\"generation\":null,\"managedFields\":null,\"resourceVersion\":null,\"uid\":null},\"spec\":{\"timeout\":null},\"status\":null}"
```

which seems pretty much what kube-apiserver is complaining about.



## Release Note

none (imo, not worth a release note)

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [ ] Removed non-atomic or `wip` commits
- [ ] Filled in the [Release Note](#Release-Note) section above
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->



