### PR TITLE
Add tekton install step to pre-reqs in README

### DIFF
--- a/examples/source-to-knative-service/README.md
+++ b/examples/source-to-knative-service/README.md
@@ -64,6 +64,15 @@ supplychain, forms something powerful.
 
 In this example, we leverage the following dependencies:
 
+- [tekton], for providing a mechanism to create pipelines (for application testing, scanning, etc)
+
+```bash
+TEKTON_VERSION=0.30.0
+
+kapp deploy --yes -a tekton \
+	-f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.30.0/release.yaml
+```
+
 - [kpack], for providing an opinionated way of continuously building container
   images using buildpacks
 
@@ -857,3 +866,4 @@ same ideas here, but adds [knative] and [kapp-controller] to the mix.
 [reference]: ../../site/content/docs/reference.md
 [source-controller]: https://github.com/fluxcd/source-controller
 [ytt]: https://carvel.dev/ytt
+[tekton]: https://github.com/tektoncd/pipeline


### PR DESCRIPTION
As written, the `source-to-knative-service` example was missing the tekton installation step, and deployment of the example resulted in the following error:

```
~/workspace/cartographer/examples/source-to-knative-service$ ytt --ignore-unknown-comments -f . | kapp deploy --yes -a example -f-
Target cluster 'https://kubernetes.docker.internal:6443' (nodes: docker-desktop)

kapp: Error: Expected to find kind 'tekton.dev/v1beta1/Task', but did not:
- Kubernetes API server did not have matching apiVersion + kind
- No matching CRD was found in given configuration
```

Fix: Added instructions to install tekton to the README.md.