### PR TITLE
cmd: pass context through args

### DIFF
--- a/cmd/cartographer/main.go
+++ b/cmd/cartographer/main.go
@@ -40,7 +40,6 @@ func init() {
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
-
 	defer cancel()
 
 	loggerOpt, err := logger.SetLogLevel(verbosity)
@@ -51,11 +50,10 @@ func main() {
 	cmd := root.Command{
 		Port:    port,
 		CertDir: certDir,
-		Context: ctx,
 		Logger:  zap.New(zap.UseDevMode(devMode), loggerOpt),
 	}
 
-	if err = cmd.Execute(); err != nil {
+	if err = cmd.Execute(ctx); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/registrar/registrar.go
+++ b/pkg/registrar/registrar.go
@@ -312,7 +312,7 @@ func registerRunnableController(mgr manager.Manager) error {
 	return nil
 }
 
-func IndexResources(mgr manager.Manager, ctx context.Context) error {
+func IndexResources(ctx context.Context, mgr manager.Manager) error {
 	fieldIndexer := mgr.GetFieldIndexer()
 
 	if err := indexSupplyChains(ctx, fieldIndexer); err != nil {

--- a/pkg/root/root.go
+++ b/pkg/root/root.go
@@ -32,11 +32,10 @@ import (
 type Command struct {
 	Port    int
 	CertDir string
-	Context context.Context
 	Logger  logr.Logger
 }
 
-func (cmd *Command) Execute() error {
+func (cmd *Command) Execute(ctx context.Context) error {
 	log.SetLogger(cmd.Logger)
 	l := log.Log.WithName("cartographer")
 
@@ -65,7 +64,7 @@ func (cmd *Command) Execute() error {
 		return fmt.Errorf("register controllers: %w", err)
 	}
 
-	if err := registrar.IndexResources(mgr, cmd.Context); err != nil {
+	if err := registrar.IndexResources(ctx, mgr); err != nil {
 		return fmt.Errorf("index resources: %w", err)
 	}
 
@@ -109,7 +108,7 @@ func (cmd *Command) Execute() error {
 		}
 	}
 
-	if err := mgr.Start(cmd.Context); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		return fmt.Errorf("manager start: %w", err)
 	}
 

--- a/tests/integration/delivery/delivery_suite_test.go
+++ b/tests/integration/delivery/delivery_suite_test.go
@@ -105,11 +105,10 @@ var _ = BeforeSuite(func() {
 		controller = &root.Command{
 			Port:    testEnv.WebhookInstallOptions.LocalServingPort,
 			CertDir: testEnv.WebhookInstallOptions.LocalServingCertDir,
-			Context: ctx,
 			Logger:  logger,
 		}
 
-		controllerError <- controller.Execute()
+		controllerError <- controller.Execute(ctx)
 	}()
 
 	// Can take a long time to start serving

--- a/tests/integration/runnable/runnable_suite_test.go
+++ b/tests/integration/runnable/runnable_suite_test.go
@@ -104,11 +104,10 @@ var _ = BeforeSuite(func() {
 		controller = &root.Command{
 			Port:    testEnv.WebhookInstallOptions.LocalServingPort,
 			CertDir: testEnv.WebhookInstallOptions.LocalServingCertDir,
-			Context: ctx,
 			Logger:  logger,
 		}
 
-		controllerError <- controller.Execute()
+		controllerError <- controller.Execute(ctx)
 	}()
 
 	// Can take a long time to start serving

--- a/tests/integration/supplychain/supply_chain_suite_test.go
+++ b/tests/integration/supplychain/supply_chain_suite_test.go
@@ -106,11 +106,10 @@ var _ = BeforeSuite(func() {
 		controller = &root.Command{
 			Port:    testEnv.WebhookInstallOptions.LocalServingPort,
 			CertDir: testEnv.WebhookInstallOptions.LocalServingCertDir,
-			Context: ctx,
 			Logger:  logger,
 		}
 
-		controllerError <- controller.Execute()
+		controllerError <- controller.Execute(ctx)
 	}()
 
 	// Can take a long time to start serving


### PR DESCRIPTION
  ## Changes proposed by this PR

  - make use of function args for ctx passing rather than struct

  closes #361

  ## Release Note

  none (very cosmetic)

  ## PR Checklist

  Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

  - [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
  - [ ] Removed non-atomic or `wip` commits
  - [ ] Filled in the [Release Note](#Release-Note) section above
  - [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
