### PR TITLE
cmd: context cancellation on signal

### DIFF
--- a/cmd/cartographer/main.go
+++ b/cmd/cartographer/main.go
@@ -15,10 +15,10 @@
 package main
 
 import (
-	"context"
 	"flag"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/vmware-tanzu/cartographer/pkg/logger"
@@ -39,9 +39,6 @@ func init() {
 }
 
 func main() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	loggerOpt, err := logger.SetLogLevel(verbosity)
 	if err != nil {
 		panic(err)
@@ -53,7 +50,7 @@ func main() {
 		Logger:  zap.New(zap.UseDevMode(devMode), loggerOpt),
 	}
 
-	if err = cmd.Execute(ctx); err != nil {
+	if err = cmd.Execute(ctrl.SetupSignalHandler()); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
  ## Changes proposed by this PR

  - start the root context with a handler that gets cancelled when receiving                                                                                                                               termination signals (see
  [SetupSignalHandler()](https://github.com/kubernetes-sigs/controller-runtime/blob/4d10a0615b11507451ecb58bfd59f0f6ef313a29/pkg/manager/signals/signal.go#L26-L30)).

**ps.: builds upon #370 - that should come first, if approved**

  ## Release Note

  Gracefully exit on termination signals.


  ## PR Checklist

  Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

  - [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
  - [ ] Removed non-atomic or `wip` commits
  - [ ] Filled in the [Release Note](#Release-Note) section above
  - [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
