### PR TITLE
examples: add note about doc versioning

### DIFF
--- a/examples/source-to-knative-service/README.md
+++ b/examples/source-to-knative-service/README.md
@@ -1,5 +1,13 @@
 # Source to Knative Service
 
+**before you proceed**: the example in this directory illustrates the use of
+the latest components and functionality of Cartographer (including some that
+may not have been included in the latest release yet). Make sure to check out
+the version of this document in a tag that matches the latest version (for
+instance, https://github.com/vmware-tanzu/cartographer/tree/v0.0.7/examples).
+
+---
+
 This example illustrates how an App Operator group could set up a software
 supply chain such that source code gets continuously built using the best
 practices from [buildpacks] via [kpack/Image] and deployed to the cluster using
@@ -33,7 +41,6 @@ objects would be set by the different personas in the system:
           ├── ...                                       that an app-dev submits
           └── workload.yaml
 ```
-
 
 ## Prerequisites
 


### PR DESCRIPTION
  as we update the examples with the latest features, it'll be inevitable
  that our releases will not be ready yet and people will go throguh the
  example expecting it to "just work".

  given that "just work" will always be true for examples under a
  particular tag (e.g., v0.0.7), here I point folks at such.


  ## Changes proposed by this PR

  - point folks at tagged content so there's no mismatch between the content of
    the examples and the version released

  ## Release Note

  none


  ## PR Checklist

  Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

  - [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
  - [ ] Removed non-atomic or `wip` commits
  - [ ] Filled in the [Release Note](#Release-Note) section above
  - [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
