### PR TITLE
examples: use of single serviceaccount

### DIFF
--- a/examples/source-to-knative-service/00-cluster/rbac.yaml
+++ b/examples/source-to-knative-service/00-cluster/rbac.yaml
@@ -1,0 +1,39 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kapp-permissions
+rules:
+- apiGroups:
+  - serving.knative.dev
+  resources: ['services']
+  verbs: ['*']
+- apiGroups: [""]
+  resources: ['configmaps']
+  verbs: ['*']
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kapp-permissions
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kapp-permissions
+subjects:
+  - kind: ServiceAccount
+    name: service-account

--- a/examples/source-to-knative-service/README.md
+++ b/examples/source-to-knative-service/README.md
@@ -114,12 +114,6 @@ kapp deploy --yes -a gitops-toolkit \
   Kubernetes objects as a single unit
 
 ```bash
-# THIS CLUSTERROLEBINDING IS FOR DEMO PURPOSES ONLY - THIS WILL GRANT MORE PERMISSIONS THAN NECESSARY
-#
-kubectl create clusterrolebinding default-admin \
-  --clusterrole=cluster-admin \
-  --serviceaccount=default:default
-
 KAPP_CONTROLLER_VERSION=0.30.0
 
 kapp deploy --yes -a kapp-controller \

--- a/examples/source-to-knative-service/app-operator/supply-chain-templates.yaml
+++ b/examples/source-to-knative-service/app-operator/supply-chain-templates.yaml
@@ -141,7 +141,7 @@ spec:
     metadata:
       name: $(workload.metadata.name)$
     spec:
-      serviceAccountName: default
+      serviceAccountName: service-account
       fetch:
         - inline:
             paths:
@@ -179,13 +179,12 @@ spec:
                       annotations:
                         autoscaling.knative.dev/minScale: "1"
                     spec:
+                      serviceAccountName: service-account
                       containers:
                         - name: workload
                           image: $(images.image.image)$
                           securityContext:
                             runAsUser: 1000
-                      imagePullSecrets:
-                        - name: registry-credentials
       template:
         - ytt: {}
       deploy:


### PR DESCRIPTION
## Changes proposed by this PR

- remove reliance on `default` serviceaccount having cluster-admin privs
  by providing the proper roles necessary for kapp-ctrl to deploy the ksvc
- make use of the serviceaccount created for the example in ksvc so that
  we avoid any secret lookups on the `default` SA

## Context

at the moment, we make use of `serviceAccount` in some places referring
to the `service-account` SA (which contains secrets for reaching out to
the registry w/ authz granted), but in others, we use the `default` one
(relying on people having set that up appropriate according to the
documentation).

this commit changes that, moving toward a more explicit use of a single
serviceaccount (the one named `service-account` that we create).

this should contribute to reducing some implicit problems that might
occur, like how with the lack of `serviceAccount` in the revision
templatespec for knative we end up seeing problems if `default` points
at a secret that doesn't exist anymore (as knative tries to fetch
secrets from the `default` SA if not specified).

e.g., given a serviceaccount `default` that points at secret `foo` which
doesn't exist, we'd end up with:

```
status:
  conditions:
  - lastTransitionTime: "2021-11-19T19:33:42Z"
    message: 'Revision "dev-00001" failed with message: Unable to fetch image "index.docker.io/foo/cartographer-demo-dev@sha256:a109772459cd0528493e6fa976e5b803c20914405e2041d06fbe7dcd185828f3":
      failed to resolve image to digest: failed to initialize authentication: secrets
      "foo" not found.'
```

being explicit in terms of serviceaccount, we're end up with stronger guarantees
that we'll not fall into implicit behaviors.

see https://github.com/google/go-containerregistry/blob/abdc633f83054d6a0c2d569f1dca17ccb8f1cecf/pkg/authn/k8schain/k8schain.go#L79-L90
see https://github.com/knative/serving/blob/492d71c96e7ada509f1cfeae5a8a04f1755fc9ef/pkg/reconciler/revision/resolve.go#L80-L83

/cc @ciberkleid 