### PR TITLE
Templates and blueprints need not specify defaults

### DIFF
--- a/pkg/templates/params_test.go
+++ b/pkg/templates/params_test.go
@@ -98,21 +98,21 @@ var _ = Describe("Params", func() {
 
 		Entry("value only in template",
 			templateParam,
-			&v1alpha1.DelegatableParam{},
-			&v1alpha1.DelegatableParam{},
-			&v1alpha1.Param{},
+			nil,
+			nil,
+			nil,
 			"from the template"),
 
 		Entry("no value on template, values elsewhere",
 			nil,
 			nonDelegatingBlueprintParam,
-			&v1alpha1.DelegatableParam{},
-			&v1alpha1.Param{},
-			""),
+			nil,
+			nil,
+			"from the blueprint"),
 
 		Entry("value in template, resource, and owner; resource is not overridable",
 			templateParam,
-			&v1alpha1.DelegatableParam{},
+			nil,
 			nonDelegatingResourceParam,
 			ownerParam,
 			"from the resource"),
@@ -127,7 +127,7 @@ var _ = Describe("Params", func() {
 		Entry("value in template, blueprint, and owner; blueprint is not overridable",
 			templateParam,
 			nonDelegatingBlueprintParam,
-			&v1alpha1.DelegatableParam{},
+			nil,
 			ownerParam,
 			"from the blueprint"),
 
@@ -140,7 +140,7 @@ var _ = Describe("Params", func() {
 
 		Entry("value in template, resource, and owner; resource is not overridable",
 			templateParam,
-			&v1alpha1.DelegatableParam{},
+			nil,
 			delegatingResourceParam,
 			ownerParam,
 			"from the owner"),
@@ -155,7 +155,7 @@ var _ = Describe("Params", func() {
 		Entry("value in template, blueprint, and owner; blueprint is overridable",
 			templateParam,
 			delegatingBlueprintParam,
-			&v1alpha1.DelegatableParam{},
+			nil,
 			ownerParam,
 			"from the owner"),
 
@@ -163,7 +163,7 @@ var _ = Describe("Params", func() {
 			templateParam,
 			delegatingBlueprintParam,
 			delegatingResourceParam,
-			&v1alpha1.Param{},
+			nil,
 			"from the resource"),
 
 		Entry("value in template, blueprint, resource, and owner; blueprint and resource are overridable",
@@ -175,9 +175,9 @@ var _ = Describe("Params", func() {
 
 		Entry("value in template and owner",
 			templateParam,
-			&v1alpha1.DelegatableParam{},
-			&v1alpha1.DelegatableParam{},
+			nil,
+			nil,
 			ownerParam,
-			"from the template"),
+			"from the owner"),
 	)
 })

--- a/tests/kuttl/delivery/params-delivery/00-cluster-delivery.yaml
+++ b/tests/kuttl/delivery/params-delivery/00-cluster-delivery.yaml
@@ -21,8 +21,8 @@ spec:
   selector:
     app.tanzu.vmware.com/deliverable-type: web---params-delivery
   params:
-    - name: not-on-template
-      default: never-present
+    - name: not-on-template-ovrdbl-delivery-ovrdbl-resource-on-deliverable
+      default: not-me-delivery
     - name: ovrdbl-delivery-ovrdbl-resource-on-deliverable
       default: not-me-delivery
     - name: ovrdbl-delivery-ovrdbl-resource-not-on-deliverable
@@ -53,5 +53,5 @@ spec:
           default: not-me-resource
         - name: notovrdbl-delivery-notovrdbl-resource-on-deliverable
           value: me
-        - name: not-on-template
-          default: never-present
+        - name: not-on-template-ovrdbl-delivery-ovrdbl-resource-on-deliverable
+          default: not-me-delivery

--- a/tests/kuttl/delivery/params-delivery/00-templates.yaml
+++ b/tests/kuttl/delivery/params-delivery/00-templates.yaml
@@ -22,7 +22,7 @@ spec:
     - name: on-template
       default: me
     - name: template-and-deliverable-but-not-delivery-nor-resource
-      default: me
+      default: not-me-template
     - name: ovrdbl-delivery-ovrdbl-resource-on-deliverable
       default: not-me-template
     - name: ovrdbl-delivery-ovrdbl-resource-not-on-deliverable
@@ -55,3 +55,4 @@ spec:
         who: $(params.ovrdbl-delivery-notovrdbl-resource-on-deliverable)$
         woe-is: $(params.notovrdbl-delivery-ovrdbl-resource-on-deliverable)$
         bite: $(params.notovrdbl-delivery-notovrdbl-resource-on-deliverable)$
+        dear: $(params.not-on-template-ovrdbl-delivery-ovrdbl-resource-on-deliverable)$

--- a/tests/kuttl/delivery/params-delivery/01-assert.yaml
+++ b/tests/kuttl/delivery/params-delivery/01-assert.yaml
@@ -27,6 +27,7 @@ spec:
     who: me
     woe-is: me
     bite: me
+    dear: me
 
 ---
 apiVersion: carto.run/v1alpha1

--- a/tests/kuttl/delivery/params-delivery/01-deliverable.yaml
+++ b/tests/kuttl/delivery/params-delivery/01-deliverable.yaml
@@ -28,7 +28,7 @@ spec:
         branch: prod
   params:
     - name: template-and-deliverable-but-not-delivery-nor-resource
-      value: not-me-deliverable
+      value: me
     - name: ovrdbl-delivery-ovrdbl-resource-on-deliverable
       value: me
     - name: ovrdbl-delivery-on-deliverable
@@ -41,5 +41,5 @@ spec:
       value: me
     - name: notovrdbl-delivery-notovrdbl-resource-on-deliverable
       value: not-me-deliverable
-    - name: not-on-template
-      value: never-present
+    - name: not-on-template-ovrdbl-delivery-ovrdbl-resource-on-deliverable
+      value: me

--- a/tests/kuttl/supplychain/params-supply-chain/00-proper-templates.yaml
+++ b/tests/kuttl/supplychain/params-supply-chain/00-proper-templates.yaml
@@ -21,7 +21,7 @@ spec:
     - name: on-template
       default: me
     - name: template-and-workload-but-not-supply-chain-nor-resource
-      default: me
+      default: not-me-template
     - name: ovrdbl-supply-chain-ovrdbl-resource-on-workload
       default: not-me-template
     - name: ovrdbl-supply-chain-ovrdbl-resource-not-on-workload
@@ -60,3 +60,4 @@ spec:
         bite: $(params.notovrdbl-supply-chain-notovrdbl-resource-on-workload)$
         so-help: $(params.notovrdbl-supply-chain-on-workload)$
         mercy: $(params.notovrdbl-resource-on-workload)$
+        dear: $(params.not-on-template-ovrdbl-supply-chain-ovrdbl-resource-on-workload)$

--- a/tests/kuttl/supplychain/params-supply-chain/01-supply-chain.yaml
+++ b/tests/kuttl/supplychain/params-supply-chain/01-supply-chain.yaml
@@ -20,18 +20,18 @@ spec:
   selector:
     integration-test: "params-supply-chain"
   params:
-    - name: not-on-template
-      default: never-prese
+    - name: not-on-template-ovrdbl-supply-chain-ovrdbl-resource-on-workload
+      default: not-me-supply-chain
     - name: ovrdbl-supply-chain-ovrdbl-resource-on-workload
-      default: not-me-supply-cha
+      default: not-me-supply-chain
     - name: ovrdbl-supply-chain-ovrdbl-resource-not-on-workload
-      default: not-me-supply-cha
+      default: not-me-supply-chain
     - name: ovrdbl-supply-chain-on-workload
-      default: not-me-supply-cha
+      default: not-me-supply-chain
     - name: notovrdbl-supply-chain-on-workload
       value: me
     - name: ovrdbl-supply-chain-notovrdbl-resource-on-workload
-      default: not-me-supply-cha
+      default: not-me-supply-chain
     - name: notovrdbl-supply-chain-ovrdbl-resource-on-workload
       value: not-me-supply-chain
     - name: notovrdbl-supply-chain-notovrdbl-resource-on-workload
@@ -56,5 +56,5 @@ spec:
           default: not-me-resource
         - name: notovrdbl-supply-chain-notovrdbl-resource-on-workload
           value: me
-        - name: not-on-template
-          default: never-present
+        - name: not-on-template-ovrdbl-supply-chain-ovrdbl-resource-on-workload
+          default: not-me-resource

--- a/tests/kuttl/supplychain/params-supply-chain/02-assert.yaml
+++ b/tests/kuttl/supplychain/params-supply-chain/02-assert.yaml
@@ -29,6 +29,7 @@ spec:
     bite: me
     so-help: me
     mercy: me
+    dear: me
 
 ---
 

--- a/tests/kuttl/supplychain/params-supply-chain/02-workload.yaml
+++ b/tests/kuttl/supplychain/params-supply-chain/02-workload.yaml
@@ -22,7 +22,7 @@ spec:
   serviceAccountName: my-service-account
   params:
     - name: template-and-workload-but-not-supply-chain-nor-resource
-      value: not-me-workload
+      value: me
     - name: ovrdbl-supply-chain-ovrdbl-resource-on-workload
       value: me
     - name: ovrdbl-supply-chain-on-workload
@@ -39,8 +39,8 @@ spec:
       value: me
     - name: notovrdbl-supply-chain-notovrdbl-resource-on-workload
       value: not-me-workload
-    - name: not-on-template
-      value: never-present
+    - name: not-on-template-ovrdbl-supply-chain-ovrdbl-resource-on-workload
+      value: me
 
   source:
     git:


### PR DESCRIPTION
If no default/value is provided for a param name, the workload can still provide
a value for that param name