### PR TITLE
cli: Add additionalPrinterColumns to Workload resources.

### DIFF
--- a/config/crd/bases/carto.run_deliverables.yaml
+++ b/config/crd/bases/carto.run_deliverables.yaml
@@ -30,7 +30,20 @@ spec:
     singular: deliverable
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.source['git.url','image']
+      name: Source
+      type: string
+    - jsonPath: .status.deliveryRef.name
+      name: Delivery
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/config/crd/bases/carto.run_workloads.yaml
+++ b/config/crd/bases/carto.run_workloads.yaml
@@ -30,7 +30,20 @@ spec:
     singular: workload
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.source['git.url','image']
+      name: Source
+      type: string
+    - jsonPath: .status.supplyChainRef.name
+      name: SupplyChain
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/pkg/apis/v1alpha1/deliverable.go
+++ b/pkg/apis/v1alpha1/deliverable.go
@@ -44,6 +44,10 @@ const (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Source",type="string",JSONPath=`.spec.source['git.url','image']`
+// +kubebuilder:printcolumn:name="Delivery",type="string",JSONPath=".status.deliveryRef.name"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=='Ready')].status`
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=`.status.conditions[?(@.type=='Ready')].reason`
 
 type Deliverable struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/v1alpha1/workload.go
+++ b/pkg/apis/v1alpha1/workload.go
@@ -40,7 +40,10 @@ const (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-
+// +kubebuilder:printcolumn:name="Source",type="string",JSONPath=`.spec.source['git.url','image']`
+// +kubebuilder:printcolumn:name="SupplyChain",type="string",JSONPath=".status.supplyChainRef.name"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=='Ready')].status`
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=`.status.conditions[?(@.type=='Ready')].reason`
 type Workload struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`

--- a/pkg/apis/v1alpha1/workload.go
+++ b/pkg/apis/v1alpha1/workload.go
@@ -44,6 +44,7 @@ const (
 // +kubebuilder:printcolumn:name="SupplyChain",type="string",JSONPath=".status.supplyChainRef.name"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=='Ready')].status`
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=`.status.conditions[?(@.type=='Ready')].reason`
+
 type Workload struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Cartographer!

Also check the [PR guidelines] if you haven't already!
-->

[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Changes proposed by this PR

closes #445

Adds additionalPrinterColumns to Workload via `controller-gen` annotations.


## Release Note

* `kubectl get` should now present useful information when listing Workloads.

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above 
- [x] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
