### PR TITLE
Fix failing end to end tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: setup base dependencies
         run: |-
           sudo apt update && sudo apt install -y curl tar
-          ./hack/ci/install-binaries.sh ko kubebuilder kuttl gh
+          ./hack/ci/install-binaries.sh ko kubebuilder kuttl gh tree
 
       - name: setup carvel tooling binaries
         uses: vmware-tanzu/carvel-setup-action@v1

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: setup base dependencies
         run: |-
           sudo apt update && sudo apt install -y curl tar
-          ./hack/ci/install-binaries.sh ko kubebuilder kuttl
+          ./hack/ci/install-binaries.sh ko kubebuilder kuttl tree
 
       - name: setup carvel tooling binaries
         uses: vmware-tanzu/carvel-setup-action@v1

--- a/examples/source-to-knative-service/00-cluster/kpack.yaml
+++ b/examples/source-to-knative-service/00-cluster/kpack.yaml
@@ -20,7 +20,10 @@ metadata:
   name: go-store
 spec:
   sources:
-    - image: gcr.io/paketo-buildpacks/go
+    # need to pin to go0.12 until a new kpack is released with a newer lifecycle
+    # kpack v0.4.3 (latest at the moment) has lifecycle 0.11.4 (https://github.com/pivotal/kpack/blob/v0.4.3/hack/lifecycle/main.go#L49)
+    # the latest go buildpack requires at least lifecycle 0.13.x because it requires support for buildpack API 0.7
+    - image: gcr.io/paketo-buildpacks/go:0.12.0
 
 ---
 apiVersion: kpack.io/v1alpha2

--- a/hack/ci/install-binaries.sh
+++ b/hack/ci/install-binaries.sh
@@ -25,6 +25,8 @@ readonly KUTTL_VERSION=${KUTTL_VERSION:-0.11.1}
 readonly KUTTL_CHECKSUM=${KUTTL_CHECKSUM:-0fb13f8fbb6109803a06847a8ad3fae4fedc8cd159e2b0fd6c1a1d8737191e5f}
 readonly GH_VERSION=${GH_VERSION:-2.0.0}
 readonly GH_CHECKSUM=${GH_CHECKSUM:-20c2d1b1915a0ff154df453576d9e97aab709ad4b236ce8313435b8b96d31e5c}
+readonly KUBECTL_TREE_CHECKSUM=${KUBECTL_TREE_CHECKSUM:-f4a3230d46b824889fca56525d051aad70815965a94623388ec0b5dc71781790}
+readonly KUBECTL_TREE_VERSION=${KUBECTL_TREE_VERSION:-0.4.1}
 
 main() {
         cd $(mktemp -d)
@@ -42,6 +44,9 @@ main() {
                         ;;
                 gh)
                         install_gh
+                        ;;
+                tree)
+                        install_kubectl_tree
                         ;;
                 *) ;;
                 esac
@@ -90,6 +95,17 @@ install_gh() {
         tar xzf $fname --strip-components=1
 
         mv ./bin/gh /usr/local/bin
+}
+
+install_kubectl_tree() {
+        local url=https://github.com/ahmetb/kubectl-tree/releases/download/v${KUBECTL_TREE_VERSION}/kubectl-tree_v${KUBECTL_TREE_VERSION}_linux_amd64.tar.gz
+        local fname=kubectl-tree_v${KUBECTL_TREE_VERSION}_linux_amd64.tar.gz
+
+        curl -sSOL $url
+        echo "${KUBECTL_TREE_CHECKSUM}  $fname" | sha256sum -c
+        tar xzf $fname
+
+        install -m 0755 ./kubectl-tree /usr/local/bin
 }
 
 main "$@"


### PR DESCRIPTION
## Release Note
* The end to end example now tries to run a `kubectl tree` if the workload takes too long to complete but this currently fails.
* Also pinned the go buildpack in the example to go 0.12
  * Need to pin to go0.12 until a new kpack is released with a newer lifecycle
  * Kpack v0.4.3 (latest at the moment) has lifecycle 0.11.4 (https://github.com/pivotal/kpack/blob/v0.4.3/hack/lifecycle/main.go#L49)
  * The latest go buildpack requires at least lifecycle 0.13.x because it requires support for buildpack API 0.7

## PR Checklist

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above 
- [x] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
