### PR TITLE
Add developer-facing namespaced resources to the "all" category

### DIFF
--- a/config/crd/bases/carto.run_deliverables.yaml
+++ b/config/crd/bases/carto.run_deliverables.yaml
@@ -24,6 +24,8 @@ metadata:
 spec:
   group: carto.run
   names:
+    categories:
+    - all
     kind: Deliverable
     listKind: DeliverableList
     plural: deliverables

--- a/config/crd/bases/carto.run_workloads.yaml
+++ b/config/crd/bases/carto.run_workloads.yaml
@@ -24,6 +24,8 @@ metadata:
 spec:
   group: carto.run
   names:
+    categories:
+    - all
     kind: Workload
     listKind: WorkloadList
     plural: workloads

--- a/pkg/apis/v1alpha1/deliverable.go
+++ b/pkg/apis/v1alpha1/deliverable.go
@@ -43,6 +43,7 @@ const (
 )
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 
 type Deliverable struct {

--- a/pkg/apis/v1alpha1/workload.go
+++ b/pkg/apis/v1alpha1/workload.go
@@ -39,6 +39,7 @@ const (
 )
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories="all"
 // +kubebuilder:subresource:status
 
 type Workload struct {


### PR DESCRIPTION
- Add Workloads to the "all" category
- Add Deliverable to "all" category as well.

<!--
Thanks for submitting a pull request to Cartographer!

Also check the [PR guidelines] if you haven't already!
-->

[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Changes proposed by this PR

closes #448

Uses the [`controller-gen` annotations](https://github.com/kubernetes-sigs/controller-tools/blob/c796d037386bc209fde0ca657df6b6face0ec5b7/pkg/crd/markers/crd.go#L249) to define categories for the Delivery and Workload resources.


## Release Note

* Namespace-level resources (Workloads and Deliverables) should appear in `kubectl get all`

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above 
- [x] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
