### PR TITLE
ci: add grype vuln scanning for source code & image

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: setup base dependencies
         run: |-
           sudo apt update && sudo apt install -y curl tar
-          ./hack/ci/install-binaries.sh ko kubebuilder kuttl tree
+          ./hack/ci/install-binaries.sh ko kubebuilder kuttl tree grype
 
       - name: setup carvel tooling binaries
         uses: vmware-tanzu/carvel-setup-action@v1
@@ -57,4 +57,16 @@ jobs:
         run: make test
 
       - name: run e2e example
-        run: ./hack/setup.sh cluster cartographer example-dependencies example
+        run: |-
+          sudo ./hack/ci/trust-local-registry.sh
+          ./hack/setup.sh cluster cartographer example-dependencies example
+
+      - name: scan source
+        run: |-
+          grype .
+
+      - name: scan image
+        env:
+          DOCKER_CONFIG: /tmp/cartographer-docker
+        run: |-
+          grype $(cat ./release/cartographer.yaml | grep ' image: ' | awk '{print $NF}')

--- a/hack/ci/install-binaries.sh
+++ b/hack/ci/install-binaries.sh
@@ -27,6 +27,8 @@ readonly GH_VERSION=${GH_VERSION:-2.0.0}
 readonly GH_CHECKSUM=${GH_CHECKSUM:-20c2d1b1915a0ff154df453576d9e97aab709ad4b236ce8313435b8b96d31e5c}
 readonly KUBECTL_TREE_CHECKSUM=${KUBECTL_TREE_CHECKSUM:-f4a3230d46b824889fca56525d051aad70815965a94623388ec0b5dc71781790}
 readonly KUBECTL_TREE_VERSION=${KUBECTL_TREE_VERSION:-0.4.1}
+readonly GRYPE_CHECKSUM=a0aaae28792a70fd465301cef0f3dc4bd09c2e707208f7a576e4085c8ea861d4
+readonly GRYPE_VERSION=0.27.2
 
 main() {
         cd $(mktemp -d)
@@ -47,6 +49,9 @@ main() {
                         ;;
                 tree)
                         install_kubectl_tree
+                        ;;
+                grype)
+                        install_grype
                         ;;
                 *) ;;
                 esac
@@ -106,6 +111,17 @@ install_kubectl_tree() {
         tar xzf $fname
 
         install -m 0755 ./kubectl-tree /usr/local/bin
+}
+
+install_grype() {
+        local url=https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz
+        local fname=grype_${GRYPE_VERSION}_linux_amd64.tar.gz
+
+        curl -sSOL $url
+        echo "${GRYPE_CHECKSUM}  $fname" | sha256sum -c
+        tar xzf $fname
+
+        install -m 0755 ./grype /usr/local/bin
 }
 
 main "$@"

--- a/hack/ci/trust-local-registry.sh
+++ b/hack/ci/trust-local-registry.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly local_registry=$(ip route get 8.8.8.8 | grep src | awk '{print $7}'):5000
+readonly config_file=/etc/docker/daemon.json
+
+echo "$(jq ". + {\"insecure-registries\": [\"$local_registry\"]}" $config_file)" >$config_file
+
+kill -s SIGHUP $(pidof dockerd)


### PR DESCRIPTION
## Changes proposed by this PR

from the commit message:

```
    ci: add grype scanning

    two extra steps to the validation workflow:

    - source scanning: making use of the standard go lock files, grype is
      able to crossreference that against its database (which is updated on
      every run)

    - image scanning: for the image we produced while setting up e2e, grype
      is able to lookup the debian packages inside the container image as
      well as inspect the binary that it founds there (go modules can be
      retrieved from a specific section of the binary).

    it might be seen as redundant to have the source scan, but, I found it
    useful for separating other potential problems we could see from, e.g.,
    finding vulnerabilities in the `ytt` binary that we include in the
    image to support templating w/ it.
```

capturing some thoughts out of band:

> _**scothis** in general, set things like this to alert, but not block_
> _it's easy to lose build reproducibility otherwise_

this PR does essentially that: it can tell us what vulnerabilities have been
found, but it won't block anything based on that (informational only).

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- ~[ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`~
- [ ] Removed non-atomic or `wip` commits
- [ ] Filled in the [Release Note](#Release-Note) section above 
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
