### PR TITLE
Filter on `name=gitea` to get correct container id

### DIFF
--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -188,7 +188,7 @@ start_repository() {
         docker-compose -f hack/docker-compose.yaml up -d
 
         # Apply gitea configuration
-        CONTAINER_ID=$(docker ps | cut -d ' ' -f1 | head -2 | tail -1)
+        CONTAINER_ID=$(docker ps --filter name=gitea | cut -d ' ' -f1 | head -2 | tail -1)
         docker cp hack/golden-app.ini "$CONTAINER_ID:/data/gitea/conf/app.ini"
         docker restart "$CONTAINER_ID"
 


### PR DESCRIPTION
---
name: Pull request
about: Installation of gitea for example

## Changes proposed by this PR

Add `--filter name=gitea` to line that gets the container id for the gitea container.
Otherwise, if other containers are running besides those created by this script, it is possible the wrong container id will be retrieved.

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [-] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [-] Removed non-atomic or `wip` commits
- [-] Filled in the [Release Note](#Release-Note) section above 
- [-] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
