### PR TITLE
In narrow media, the padding between nav and content should remain

### DIFF
--- a/site/themes/template/assets/scss/_components.scss
+++ b/site/themes/template/assets/scss/_components.scss
@@ -541,6 +541,8 @@
     .docs-content {
         width: 75%;
         float: right;
+        padding-left: 20px;
+
         &.full {
             width: 100%;
         }


### PR DESCRIPTION
In narrow media, the padding between nav and content should remain

## Changes proposed by this PR

When the docs are narrow, don't collapse the left padding of the doc content.
## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- ~[ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`~
- [x] Removed non-atomic or `wip` commits
- ~[ ] Filled in the [Release Note](#Release-Note) section above ~
- ~[ ] Modified the docs to match changes~
