### PR TITLE
Include resource and blueprint information in errors

### DIFF
--- a/pkg/controller/deliverable/reconciler_test.go
+++ b/pkg/controller/deliverable/reconciler_test.go
@@ -416,7 +416,8 @@ var _ = Describe("Reconciler", func() {
 				var templateError error
 				BeforeEach(func() {
 					templateError = realizer.GetDeliveryTemplateError{
-						Err: errors.New("some error"),
+						Resource: &v1alpha1.DeliveryResource{Name: "some-name"},
+						Err:      errors.New("some error"),
 					}
 					rlzr.RealizeReturns(nil, templateError)
 				})
@@ -437,8 +438,9 @@ var _ = Describe("Reconciler", func() {
 				var stampError realizer.StampError
 				BeforeEach(func() {
 					stampError = realizer.StampError{
-						Err:      errors.New("some error"),
-						Resource: &v1alpha1.DeliveryResource{Name: "some-name"},
+						Err:          errors.New("some error"),
+						Resource:     &v1alpha1.DeliveryResource{Name: "some-name"},
+						DeliveryName: "some-delivery",
 					}
 					rlzr.RealizeReturns(nil, stampError)
 				})
@@ -467,7 +469,7 @@ var _ = Describe("Reconciler", func() {
 					Expect(out).To(Say(`"msg":"handled error reconciling deliverable"`))
 					Expect(out).To(Say(`"deliverable":"my-namespace/my-deliverable-name"`))
 					Expect(out).To(Say(`"delivery":"some-delivery"`))
-					Expect(out).To(Say(`"handled error":"unable to stamp object for resource \[some-name\]: some error"`))
+					Expect(out).To(Say(`"handled error":"unable to stamp object for resource \[some-name\] in delivery \[some-delivery\]: some error"`))
 				})
 			})
 
@@ -477,6 +479,7 @@ var _ = Describe("Reconciler", func() {
 					stampedObjectError = realizer.ApplyStampedObjectError{
 						Err:           errors.New("some error"),
 						StampedObject: &unstructured.Unstructured{},
+						Resource:      &v1alpha1.DeliveryResource{Name: "some-name"},
 					}
 					rlzr.RealizeReturns(nil, stampedObjectError)
 				})
@@ -508,6 +511,8 @@ var _ = Describe("Reconciler", func() {
 					stampedObjectError = realizer.ApplyStampedObjectError{
 						Err:           kerrors.FromObject(status),
 						StampedObject: stampedObject1,
+						Resource:      &v1alpha1.DeliveryResource{Name: "some-name"},
+						DeliveryName:  deliveryName,
 					}
 
 					rlzr.RealizeReturns(nil, stampedObjectError)
@@ -523,7 +528,7 @@ var _ = Describe("Reconciler", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(out).To(Say(`"level":"info"`))
-					Expect(out).To(Say(`"handled error":"unable to apply object \[a-namespace/a-name\]: fantastic error"`))
+					Expect(out).To(Say(`"handled error":"unable to apply object \[a-namespace/a-name\] for resource \[some-name\] in delivery \[some-delivery\]: fantastic error"`))
 				})
 			})
 
@@ -545,6 +550,7 @@ var _ = Describe("Reconciler", func() {
 					retrieveError = realizer.RetrieveOutputError{
 						Err:           wrappedError,
 						Resource:      &v1alpha1.DeliveryResource{Name: "some-resource"},
+						DeliveryName:  deliveryName,
 						StampedObject: stampedObject,
 					}
 
@@ -573,7 +579,7 @@ var _ = Describe("Reconciler", func() {
 						Expect(out).To(Say(`"msg":"handled error reconciling deliverable"`))
 						Expect(out).To(Say(`"deliverable":"my-namespace/my-deliverable-name"`))
 						Expect(out).To(Say(`"delivery":"some-delivery"`))
-						Expect(out).To(Say(`"handled error":"unable to retrieve outputs from stamped object \[my-ns/my-obj\] of type \[mything.thing.io\] for resource \[some-resource\]: some error"`))
+						Expect(out).To(Say(`"handled error":"unable to retrieve outputs from stamped object \[my-ns/my-obj\] of type \[mything.thing.io\] for resource \[some-resource\] in delivery \[some-delivery\]: some error"`))
 					})
 				})
 
@@ -599,7 +605,7 @@ var _ = Describe("Reconciler", func() {
 						Expect(out).To(Say(`"msg":"handled error reconciling deliverable"`))
 						Expect(out).To(Say(`"deliverable":"my-namespace/my-deliverable-name"`))
 						Expect(out).To(Say(`"delivery":"some-delivery"`))
-						Expect(out).To(Say(`"handled error":"unable to retrieve outputs from stamped object \[my-ns/my-obj\] of type \[mything.thing.io\] for resource \[some-resource\]: some error"`))
+						Expect(out).To(Say(`"handled error":"unable to retrieve outputs from stamped object \[my-ns/my-obj\] of type \[mything.thing.io\] for resource \[some-resource\] in delivery \[some-delivery\]: some error"`))
 					})
 				})
 
@@ -625,7 +631,7 @@ var _ = Describe("Reconciler", func() {
 						Expect(out).To(Say(`"msg":"handled error reconciling deliverable"`))
 						Expect(out).To(Say(`"deliverable":"my-namespace/my-deliverable-name"`))
 						Expect(out).To(Say(`"delivery":"some-delivery"`))
-						Expect(out).To(Say(`"handled error":"unable to retrieve outputs from stamped object \[my-ns/my-obj\] of type \[mything.thing.io\] for resource \[some-resource\]: some error"`))
+						Expect(out).To(Say(`"handled error":"unable to retrieve outputs from stamped object \[my-ns/my-obj\] of type \[mything.thing.io\] for resource \[some-resource\] in delivery \[some-delivery\]: some error"`))
 					})
 				})
 
@@ -651,7 +657,7 @@ var _ = Describe("Reconciler", func() {
 						Expect(out).To(Say(`"msg":"handled error reconciling deliverable"`))
 						Expect(out).To(Say(`"deliverable":"my-namespace/my-deliverable-name"`))
 						Expect(out).To(Say(`"delivery":"some-delivery"`))
-						Expect(out).To(Say(`"handled error":"unable to retrieve outputs \[this.wont.find.anything\] from stamped object \[my-ns/my-obj\] of type \[mything.thing.io\] for resource \[some-resource\]: failed to evaluate json path 'this.wont.find.anything': some error"`))
+						Expect(out).To(Say(`"handled error":"unable to retrieve outputs \[this.wont.find.anything\] from stamped object \[my-ns/my-obj\] of type \[mything.thing.io\] for resource \[some-resource\] in delivery \[some-delivery\]: failed to evaluate json path 'this.wont.find.anything': some error"`))
 					})
 				})
 
@@ -677,7 +683,7 @@ var _ = Describe("Reconciler", func() {
 						Expect(out).To(Say(`"msg":"handled error reconciling deliverable"`))
 						Expect(out).To(Say(`"deliverable":"my-namespace/my-deliverable-name"`))
 						Expect(out).To(Say(`"delivery":"some-delivery"`))
-						Expect(out).To(Say(`"handled error":"unable to retrieve outputs from stamped object \[my-ns/my-obj\] of type \[mything.thing.io\] for resource \[some-resource\]: some error"`))
+						Expect(out).To(Say(`"handled error":"unable to retrieve outputs from stamped object \[my-ns/my-obj\] of type \[mything.thing.io\] for resource \[some-resource\] in delivery \[some-delivery\]: some error"`))
 					})
 				})
 			})

--- a/pkg/controller/runnable/reconciler_test.go
+++ b/pkg/controller/runnable/reconciler_test.go
@@ -364,8 +364,8 @@ var _ = Describe("Reconcile", func() {
 				var err error
 				BeforeEach(func() {
 					err = realizer.GetRunTemplateError{
-						Err:      errors.New("some error"),
-						Runnable: &v1alpha1.Runnable{ObjectMeta: metav1.ObjectMeta{Name: "my-runnable", Namespace: "my-ns"}},
+						Err:         errors.New("some error"),
+						TemplateRef: &v1alpha1.TemplateReference{Kind: "ClusterRunTemplate", Name: "my-run-template"},
 					}
 					rlzr.RealizeReturns(nil, nil, err)
 				})
@@ -378,7 +378,7 @@ var _ = Describe("Reconcile", func() {
 				It("returns an unhandled error and requeues", func() {
 					_, err := reconciler.Reconcile(ctx, request)
 
-					Expect(err.Error()).To(ContainSubstring("unable to get runnable [my-ns/my-runnable]: some error"))
+					Expect(err.Error()).To(ContainSubstring("unable to get run template [my-run-template]: some error"))
 				})
 			})
 
@@ -421,8 +421,8 @@ var _ = Describe("Reconcile", func() {
 				var err error
 				BeforeEach(func() {
 					err = realizer.StampError{
-						Err:      errors.New("some error"),
-						Runnable: &v1alpha1.Runnable{ObjectMeta: metav1.ObjectMeta{Name: "my-runnable", Namespace: "my-ns"}},
+						Err:         errors.New("some error"),
+						TemplateRef: &v1alpha1.TemplateReference{Kind: "ClusterRunTemplate", Name: "my-run-template"},
 					}
 					rlzr.RealizeReturns(nil, nil, err)
 				})
@@ -449,7 +449,7 @@ var _ = Describe("Reconcile", func() {
 
 					Expect(out).To(Say(`"level":"info"`))
 					Expect(out).To(Say(`"msg":"handled error reconciling runnable"`))
-					Expect(out).To(Say(`"handled error":"unable to stamp object \[my-ns/my-runnable\]: some error"`))
+					Expect(out).To(Say(`"handled error":"unable to stamp object for run template \[my-run-template\]: some error"`))
 				})
 			})
 
@@ -459,6 +459,7 @@ var _ = Describe("Reconcile", func() {
 					err = realizer.ApplyStampedObjectError{
 						Err:           errors.New("some error"),
 						StampedObject: &unstructured.Unstructured{},
+						TemplateRef:   &v1alpha1.TemplateReference{Kind: "ClusterRunTemplate", Name: "my-run-template"},
 					}
 					rlzr.RealizeReturns(nil, nil, err)
 				})
@@ -471,7 +472,7 @@ var _ = Describe("Reconcile", func() {
 				It("returns an unhandled error and requeues", func() {
 					_, err := reconciler.Reconcile(ctx, request)
 
-					Expect(err.Error()).To(ContainSubstring("unable to apply stamped object"))
+					Expect(err.Error()).To(ContainSubstring("unable to apply object"))
 				})
 			})
 
@@ -495,6 +496,7 @@ var _ = Describe("Reconcile", func() {
 					stampedObjectError = realizer.ApplyStampedObjectError{
 						Err:           kerrors.FromObject(status),
 						StampedObject: stampedObject,
+						TemplateRef:   &v1alpha1.TemplateReference{Kind: "ClusterRunTemplate", Name: "my-run-template"},
 					}
 
 					rlzr.RealizeReturns(nil, nil, stampedObjectError)
@@ -510,7 +512,7 @@ var _ = Describe("Reconcile", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(out).To(Say(`"level":"info"`))
-					Expect(out).To(Say(`"handled error":"unable to apply stamped object \[a-namespace/a-name\]: fantastic error"`))
+					Expect(out).To(Say(`"handled error":"unable to apply object \[a-namespace/a-name\] for run template \[my-run-template\]: fantastic error"`))
 				})
 			})
 
@@ -553,7 +555,7 @@ var _ = Describe("Reconcile", func() {
 
 					err = realizer.RetrieveOutputError{
 						Err:           errors.New("some error"),
-						Runnable:      &v1alpha1.Runnable{ObjectMeta: metav1.ObjectMeta{Name: "my-runnable", Namespace: "my-ns"}},
+						TemplateRef:   &v1alpha1.TemplateReference{Kind: "ClusterRunTemplate", Name: "my-run-template"},
 						StampedObject: stampedObject,
 					}
 					rlzr.RealizeReturns(nil, nil, err)
@@ -574,7 +576,7 @@ var _ = Describe("Reconcile", func() {
 
 					Expect(out).To(Say(`"level":"info"`))
 					Expect(out).To(Say(`"msg":"handled error reconciling runnable"`))
-					Expect(out).To(Say(`"handled error":"unable to retrieve outputs from stamped object \[my-ns/my-obj\] of type \[mything.thing.io\] for runnable \[my-ns/my-runnable\]: some error"`))
+					Expect(out).To(Say(`"handled error":"unable to retrieve outputs from stamped object \[my-ns/my-obj\] of type \[mything.thing.io\] for run template \[my-run-template\]: some error"`))
 				})
 			})
 

--- a/pkg/controller/workload/reconciler_test.go
+++ b/pkg/controller/workload/reconciler_test.go
@@ -405,7 +405,8 @@ var _ = Describe("Reconciler", func() {
 				var templateError error
 				BeforeEach(func() {
 					templateError = realizer.GetSupplyChainTemplateError{
-						Err: errors.New("some error"),
+						Err:      errors.New("some error"),
+						Resource: &v1alpha1.SupplyChainResource{Name: "some-name"},
 					}
 					rlzr.RealizeReturns(nil, templateError)
 				})
@@ -426,8 +427,9 @@ var _ = Describe("Reconciler", func() {
 				var stampError realizer.StampError
 				BeforeEach(func() {
 					stampError = realizer.StampError{
-						Err:      errors.New("some error"),
-						Resource: &v1alpha1.SupplyChainResource{Name: "some-name"},
+						Err:             errors.New("some error"),
+						Resource:        &v1alpha1.SupplyChainResource{Name: "some-name"},
+						SupplyChainName: supplyChainName,
 					}
 					rlzr.RealizeReturns(nil, stampError)
 				})
@@ -454,7 +456,7 @@ var _ = Describe("Reconciler", func() {
 
 					Expect(out).To(Say(`"level":"info"`))
 					Expect(out).To(Say(`"msg":"handled error reconciling workload"`))
-					Expect(out).To(Say(`"handled error":"unable to stamp object for resource \[some-name\]: some error"`))
+					Expect(out).To(Say(`"handled error":"unable to stamp object for resource \[some-name\] in supply chain \[some-supply-chain\]: some error"`))
 				})
 			})
 
@@ -464,6 +466,7 @@ var _ = Describe("Reconciler", func() {
 					stampedObjectError = realizer.ApplyStampedObjectError{
 						Err:           errors.New("some error"),
 						StampedObject: &unstructured.Unstructured{},
+						Resource:      &v1alpha1.SupplyChainResource{Name: "some-name"},
 					}
 					rlzr.RealizeReturns(nil, stampedObjectError)
 				})
@@ -493,8 +496,10 @@ var _ = Describe("Reconciler", func() {
 					stampedObject1.SetName("a-name")
 
 					stampedObjectError = realizer.ApplyStampedObjectError{
-						Err:           kerrors.FromObject(status),
-						StampedObject: stampedObject1,
+						Err:             kerrors.FromObject(status),
+						StampedObject:   stampedObject1,
+						Resource:        &v1alpha1.SupplyChainResource{Name: "some-name"},
+						SupplyChainName: supplyChainName,
 					}
 
 					rlzr.RealizeReturns(nil, stampedObjectError)
@@ -510,7 +515,7 @@ var _ = Describe("Reconciler", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(out).To(Say(`"level":"info"`))
-					Expect(out).To(Say(`"handled error":"unable to apply object \[a-namespace/a-name\]: fantastic error"`))
+					Expect(out).To(Say(`"handled error":"unable to apply object \[a-namespace/a-name\] for resource \[some-name\] in supply chain \[some-supply-chain\]: fantastic error"`))
 				})
 			})
 
@@ -528,9 +533,10 @@ var _ = Describe("Reconciler", func() {
 					stampedObject.SetNamespace("my-ns")
 					jsonPathError := templates.NewJsonPathError("this.wont.find.anything", errors.New("some error"))
 					retrieveError = realizer.RetrieveOutputError{
-						Err:           jsonPathError,
-						Resource:      &v1alpha1.SupplyChainResource{Name: "some-resource"},
-						StampedObject: stampedObject,
+						Err:             jsonPathError,
+						Resource:        &v1alpha1.SupplyChainResource{Name: "some-resource"},
+						StampedObject:   stampedObject,
+						SupplyChainName: supplyChainName,
 					}
 					rlzr.RealizeReturns(nil, retrieveError)
 				})
@@ -551,7 +557,7 @@ var _ = Describe("Reconciler", func() {
 
 					Expect(out).To(Say(`"level":"info"`))
 					Expect(out).To(Say(`"msg":"handled error reconciling workload"`))
-					Expect(out).To(Say(`"handled error":"unable to retrieve outputs \[this.wont.find.anything\] from stamped object \[my-ns/my-obj\] of type \[mything.thing.io\] for resource \[some-resource\]: failed to evaluate json path 'this.wont.find.anything': some error"`))
+					Expect(out).To(Say(`"handled error":"unable to retrieve outputs \[this.wont.find.anything\] from stamped object \[my-ns/my-obj\] of type \[mything.thing.io\] for resource \[some-resource\] in supply chain \[some-supply-chain\]: failed to evaluate json path 'this.wont.find.anything': some error"`))
 				})
 			})
 

--- a/pkg/realizer/deliverable/component.go
+++ b/pkg/realizer/deliverable/component.go
@@ -68,8 +68,9 @@ func (r *resourceRealizer) Do(ctx context.Context, resource *v1alpha1.DeliveryRe
 	if err != nil {
 		log.Error(err, "failed to get delivery cluster template")
 		return nil, nil, GetDeliveryTemplateError{
-			Err:         err,
-			TemplateRef: resource.TemplateRef,
+			Err:          err,
+			DeliveryName: deliveryName,
+			Resource:     resource,
 		}
 	}
 
@@ -110,8 +111,9 @@ func (r *resourceRealizer) Do(ctx context.Context, resource *v1alpha1.DeliveryRe
 	if err != nil {
 		log.Error(err, "failed to stamp resource")
 		return nil, nil, StampError{
-			Err:      err,
-			Resource: resource,
+			Err:          err,
+			Resource:     resource,
+			DeliveryName: deliveryName,
 		}
 	}
 
@@ -121,6 +123,8 @@ func (r *resourceRealizer) Do(ctx context.Context, resource *v1alpha1.DeliveryRe
 		return nil, nil, ApplyStampedObjectError{
 			Err:           err,
 			StampedObject: stampedObject,
+			DeliveryName:  deliveryName,
+			Resource:      resource,
 		}
 	}
 
@@ -133,6 +137,7 @@ func (r *resourceRealizer) Do(ctx context.Context, resource *v1alpha1.DeliveryRe
 		return stampedObject, nil, RetrieveOutputError{
 			Err:           err,
 			Resource:      resource,
+			DeliveryName:  deliveryName,
 			StampedObject: stampedObject,
 		}
 	}

--- a/pkg/realizer/deliverable/errors.go
+++ b/pkg/realizer/deliverable/errors.go
@@ -26,34 +26,54 @@ import (
 const NoJsonpathContext = "<no jsonpath context>"
 
 type GetDeliveryTemplateError struct {
-	Err         error
-	TemplateRef v1alpha1.DeliveryTemplateReference
+	Err          error
+	DeliveryName string
+	Resource     *v1alpha1.DeliveryResource
 }
 
 func (e GetDeliveryTemplateError) Error() string {
-	return fmt.Errorf("unable to get template [%s]: %w", e.TemplateRef.Name, e.Err).Error()
+	return fmt.Errorf("unable to get template [%s] for resource [%s] in delivery [%s]: %w",
+		e.Resource.TemplateRef.Name,
+		e.Resource.Name,
+		e.DeliveryName,
+		e.Err,
+	).Error()
 }
 
 type ApplyStampedObjectError struct {
 	Err           error
+	DeliveryName  string
 	StampedObject *unstructured.Unstructured
+	Resource      *v1alpha1.DeliveryResource
 }
 
 func (e ApplyStampedObjectError) Error() string {
-	return fmt.Errorf("unable to apply object [%s/%s]: %w", e.StampedObject.GetNamespace(), e.StampedObject.GetName(), e.Err).Error()
+	return fmt.Errorf("unable to apply object [%s/%s] for resource [%s] in delivery [%s]: %w",
+		e.StampedObject.GetNamespace(),
+		e.StampedObject.GetName(),
+		e.Resource.Name,
+		e.DeliveryName,
+		e.Err,
+	).Error()
 }
 
 type StampError struct {
-	Err      error
-	Resource *v1alpha1.DeliveryResource
+	Err          error
+	DeliveryName string
+	Resource     *v1alpha1.DeliveryResource
 }
 
 func (e StampError) Error() string {
-	return fmt.Errorf("unable to stamp object for resource [%s]: %w", e.Resource.Name, e.Err).Error()
+	return fmt.Errorf("unable to stamp object for resource [%s] in delivery [%s]: %w",
+		e.Resource.Name,
+		e.DeliveryName,
+		e.Err,
+	).Error()
 }
 
 type RetrieveOutputError struct {
 	Err           error
+	DeliveryName  string
 	Resource      *v1alpha1.DeliveryResource
 	StampedObject *unstructured.Unstructured
 }
@@ -64,15 +84,24 @@ type JsonPathErrorContext interface {
 
 func (e RetrieveOutputError) Error() string {
 	if e.JsonPathExpression() == NoJsonpathContext {
-		return fmt.Errorf("unable to retrieve outputs from stamped object [%s/%s] of type [%s] for resource [%s]: %w",
-			e.StampedObject.GetNamespace(), e.StampedObject.GetName(),
+		return fmt.Errorf("unable to retrieve outputs from stamped object [%s/%s] of type [%s] for resource [%s] in delivery [%s]: %w",
+			e.StampedObject.GetNamespace(),
+			e.StampedObject.GetName(),
 			utils.GetFullyQualifiedType(e.StampedObject),
-			e.Resource.Name, e.Err).Error()
+			e.Resource.Name,
+			e.DeliveryName,
+			e.Err,
+		).Error()
 	}
-	return fmt.Errorf("unable to retrieve outputs [%s] from stamped object [%s/%s] of type [%s] for resource [%s]: %w",
-		e.JsonPathExpression(), e.StampedObject.GetNamespace(), e.StampedObject.GetName(),
+	return fmt.Errorf("unable to retrieve outputs [%s] from stamped object [%s/%s] of type [%s] for resource [%s] in delivery [%s]: %w",
+		e.JsonPathExpression(),
+		e.StampedObject.GetNamespace(),
+		e.StampedObject.GetName(),
 		utils.GetFullyQualifiedType(e.StampedObject),
-		e.Resource.Name, e.Err).Error()
+		e.Resource.Name,
+		e.DeliveryName,
+		e.Err,
+	).Error()
 }
 
 func (e RetrieveOutputError) ResourceName() string {

--- a/pkg/realizer/runnable/errors.go
+++ b/pkg/realizer/runnable/errors.go
@@ -24,13 +24,15 @@ import (
 )
 
 type GetRunTemplateError struct {
-	Err      error
-	Runnable *v1alpha1.Runnable
+	Err         error
+	TemplateRef *v1alpha1.TemplateReference
 }
 
 func (e GetRunTemplateError) Error() string {
-	return fmt.Errorf("unable to get runnable [%s/%s]: %w",
-		e.Runnable.Namespace, e.Runnable.Name, e.Err).Error()
+	return fmt.Errorf("unable to get run template [%s]: %w",
+		e.TemplateRef.Name,
+		e.Err,
+	).Error()
 }
 
 type ResolveSelectorError struct {
@@ -43,22 +45,26 @@ func (e ResolveSelectorError) Error() string {
 		e.Selector.MatchingLabels,
 		e.Selector.Resource.APIVersion,
 		e.Selector.Resource.Kind,
-		e.Err).Error()
+		e.Err,
+	).Error()
 }
 
 type StampError struct {
-	Err      error
-	Runnable *v1alpha1.Runnable
+	Err         error
+	TemplateRef *v1alpha1.TemplateReference
 }
 
 func (e StampError) Error() string {
-	return fmt.Errorf("unable to stamp object [%s/%s]: %w",
-		e.Runnable.Namespace, e.Runnable.Name, e.Err).Error()
+	return fmt.Errorf("unable to stamp object for run template [%s]: %w",
+		e.TemplateRef.Name,
+		e.Err,
+	).Error()
 }
 
 type ApplyStampedObjectError struct {
 	Err           error
 	StampedObject *unstructured.Unstructured
+	TemplateRef   *v1alpha1.TemplateReference
 }
 
 func (e ApplyStampedObjectError) Error() string {
@@ -66,8 +72,12 @@ func (e ApplyStampedObjectError) Error() string {
 	if name == "" {
 		name = e.StampedObject.GetGenerateName()
 	}
-	return fmt.Errorf("unable to apply stamped object [%s/%s]: %w",
-		e.StampedObject.GetNamespace(), name, e.Err).Error()
+	return fmt.Errorf("unable to apply object [%s/%s] for run template [%s]: %w",
+		e.StampedObject.GetNamespace(),
+		name,
+		e.TemplateRef.Name,
+		e.Err,
+	).Error()
 }
 
 type ListCreatedObjectsError struct {
@@ -78,13 +88,16 @@ type ListCreatedObjectsError struct {
 
 func (e ListCreatedObjectsError) Error() string {
 	return fmt.Errorf("unable to list objects in namespace [%s] with labels [%v]: %w",
-		e.Namespace, e.Labels, e.Err).Error()
+		e.Namespace,
+		e.Labels,
+		e.Err,
+	).Error()
 }
 
 type RetrieveOutputError struct {
 	Err           error
-	Runnable      *v1alpha1.Runnable
 	StampedObject *unstructured.Unstructured
+	TemplateRef   *v1alpha1.TemplateReference
 }
 
 func (e RetrieveOutputError) Error() string {
@@ -93,8 +106,11 @@ func (e RetrieveOutputError) Error() string {
 		name = e.StampedObject.GetGenerateName()
 	}
 
-	return fmt.Errorf("unable to retrieve outputs from stamped object [%s/%s] of type [%s] for runnable [%s/%s]: %w",
-		e.StampedObject.GetNamespace(), name,
+	return fmt.Errorf("unable to retrieve outputs from stamped object [%s/%s] of type [%s] for run template [%s]: %w",
+		e.StampedObject.GetNamespace(),
+		name,
 		utils.GetFullyQualifiedType(e.StampedObject),
-		e.Runnable.Namespace, e.Runnable.Name, e.Err).Error()
+		e.TemplateRef.Name,
+		e.Err,
+	).Error()
 }

--- a/pkg/realizer/runnable/realizer.go
+++ b/pkg/realizer/runnable/realizer.go
@@ -56,8 +56,8 @@ func (p *runnableRealizer) Realize(ctx context.Context, runnable *v1alpha1.Runna
 	if err != nil {
 		log.Error(err, "failed to get runnable cluster template")
 		return nil, nil, GetRunTemplateError{
-			Err:      err,
-			Runnable: runnable,
+			Err:         err,
+			TemplateRef: &runnable.Spec.RunTemplateRef,
 		}
 	}
 
@@ -90,8 +90,8 @@ func (p *runnableRealizer) Realize(ctx context.Context, runnable *v1alpha1.Runna
 	if err != nil {
 		log.Error(err, "failed to stamp resource")
 		return nil, nil, StampError{
-			Err:      err,
-			Runnable: runnable,
+			Err:         err,
+			TemplateRef: &runnable.Spec.RunTemplateRef,
 		}
 	}
 
@@ -102,6 +102,7 @@ func (p *runnableRealizer) Realize(ctx context.Context, runnable *v1alpha1.Runna
 		return nil, nil, ApplyStampedObjectError{
 			Err:           err,
 			StampedObject: stampedObject,
+			TemplateRef:   &runnable.Spec.RunTemplateRef,
 		}
 	}
 
@@ -123,8 +124,8 @@ func (p *runnableRealizer) Realize(ctx context.Context, runnable *v1alpha1.Runna
 		log.Error(err, "failed to retrieve output from object")
 		return stampedObject, nil, RetrieveOutputError{
 			Err:           err,
-			Runnable:      runnable,
 			StampedObject: stampedObject,
+			TemplateRef:   &runnable.Spec.RunTemplateRef,
 		}
 	}
 	log.V(logger.DEBUG).Info("retrieved output from stamped object", "stamped object", evaluatedStampedObject)

--- a/pkg/realizer/runnable/realizer_test.go
+++ b/pkg/realizer/runnable/realizer_test.go
@@ -333,7 +333,7 @@ var _ = Describe("Realizer", func() {
 		It("returns RetrieveOutputError", func() {
 			_, _, err := rlzr.Realize(ctx, runnable, systemRepo, runnableRepo)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(`unable to retrieve outputs from stamped object [my-important-ns/my-stamped-resource-] of type [configmap] for runnable [my-important-ns/my-runnable]: failed to evaluate path [data.hasnot]: evaluate: failed to find results: hasnot is not found`))
+			Expect(err.Error()).To(ContainSubstring(`unable to retrieve outputs from stamped object [my-important-ns/my-stamped-resource-] of type [configmap] for run template [my-template]: failed to evaluate path [data.hasnot]: evaluate: failed to find results: hasnot is not found`))
 			Expect(reflect.TypeOf(err).String()).To(Equal("runnable.RetrieveOutputError"))
 		})
 	})
@@ -351,7 +351,7 @@ var _ = Describe("Realizer", func() {
 		It("returns StampError", func() {
 			_, _, err := rlzr.Realize(ctx, runnable, systemRepo, runnableRepo)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(`unable to stamp object [my-important-ns/my-runnable]: failed to unmarshal json resource template: unexpected end of JSON input`))
+			Expect(err.Error()).To(ContainSubstring(`unable to stamp object for run template [my-template]: failed to unmarshal json resource template: unexpected end of JSON input`))
 			Expect(reflect.TypeOf(err).String()).To(Equal("runnable.StampError"))
 		})
 	})
@@ -371,7 +371,7 @@ var _ = Describe("Realizer", func() {
 		It("returns GetRunTemplateError", func() {
 			_, _, err := rlzr.Realize(ctx, runnable, systemRepo, runnableRepo)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(`unable to get runnable [my-important-ns/my-runnable]: Errol mcErrorFace`))
+			Expect(err.Error()).To(ContainSubstring(`unable to get run template [my-template]: Errol mcErrorFace`))
 			Expect(reflect.TypeOf(err).String()).To(Equal("runnable.GetRunTemplateError"))
 		})
 	})

--- a/pkg/realizer/workload/component.go
+++ b/pkg/realizer/workload/component.go
@@ -71,8 +71,9 @@ func (r *resourceRealizer) Do(ctx context.Context, resource *v1alpha1.SupplyChai
 	if err != nil {
 		log.Error(err, "failed to get cluster template")
 		return nil, nil, GetSupplyChainTemplateError{
-			Err:         err,
-			TemplateRef: resource.TemplateRef,
+			Err:             err,
+			SupplyChainName: supplyChainName,
+			Resource:        resource,
 		}
 	}
 
@@ -117,8 +118,9 @@ func (r *resourceRealizer) Do(ctx context.Context, resource *v1alpha1.SupplyChai
 	if err != nil {
 		log.Error(err, "failed to stamp resource")
 		return nil, nil, StampError{
-			Err:      err,
-			Resource: resource,
+			Err:             err,
+			Resource:        resource,
+			SupplyChainName: supplyChainName,
 		}
 	}
 
@@ -126,8 +128,10 @@ func (r *resourceRealizer) Do(ctx context.Context, resource *v1alpha1.SupplyChai
 	if err != nil {
 		log.Error(err, "failed to ensure object exists on cluster", "object", stampedObject)
 		return nil, nil, ApplyStampedObjectError{
-			Err:           err,
-			StampedObject: stampedObject,
+			Err:             err,
+			StampedObject:   stampedObject,
+			SupplyChainName: supplyChainName,
+			Resource:        resource,
 		}
 	}
 
@@ -137,9 +141,10 @@ func (r *resourceRealizer) Do(ctx context.Context, resource *v1alpha1.SupplyChai
 	if err != nil {
 		log.Error(err, "failed to retrieve output from object", "object", stampedObject)
 		return stampedObject, nil, RetrieveOutputError{
-			Err:           err,
-			Resource:      resource,
-			StampedObject: stampedObject,
+			Err:             err,
+			Resource:        resource,
+			SupplyChainName: supplyChainName,
+			StampedObject:   stampedObject,
 		}
 	}
 

--- a/pkg/realizer/workload/errors.go
+++ b/pkg/realizer/workload/errors.go
@@ -24,43 +24,68 @@ import (
 )
 
 type GetSupplyChainTemplateError struct {
-	Err         error
-	TemplateRef v1alpha1.SupplyChainTemplateReference
+	Err             error
+	SupplyChainName string
+	Resource        *v1alpha1.SupplyChainResource
 }
 
 func (e GetSupplyChainTemplateError) Error() string {
-	return fmt.Errorf("unable to get template [%s]: %w", e.TemplateRef.Name, e.Err).Error()
+	return fmt.Errorf("unable to get template [%s] for resource [%s] in supply chain [%s]: %w",
+		e.Resource.TemplateRef.Name,
+		e.Resource.Name,
+		e.SupplyChainName,
+		e.Err,
+	).Error()
 }
 
 type ApplyStampedObjectError struct {
-	Err           error
-	StampedObject *unstructured.Unstructured
+	Err             error
+	SupplyChainName string
+	StampedObject   *unstructured.Unstructured
+	Resource        *v1alpha1.SupplyChainResource
 }
 
 func (e ApplyStampedObjectError) Error() string {
-	return fmt.Errorf("unable to apply object [%s/%s]: %w", e.StampedObject.GetNamespace(), e.StampedObject.GetName(), e.Err).Error()
+	return fmt.Errorf("unable to apply object [%s/%s] for resource [%s] in supply chain [%s]: %w",
+		e.StampedObject.GetNamespace(),
+		e.StampedObject.GetName(),
+		e.Resource.Name,
+		e.SupplyChainName,
+		e.Err,
+	).Error()
 }
 
 type StampError struct {
-	Err      error
-	Resource *v1alpha1.SupplyChainResource
+	Err             error
+	SupplyChainName string
+	Resource        *v1alpha1.SupplyChainResource
 }
 
 func (e StampError) Error() string {
-	return fmt.Errorf("unable to stamp object for resource [%s]: %w", e.Resource.Name, e.Err).Error()
+	return fmt.Errorf("unable to stamp object for resource [%s] in supply chain [%s]: %w",
+		e.Resource.Name,
+		e.SupplyChainName,
+		e.Err,
+	).Error()
 }
 
 type RetrieveOutputError struct {
-	Err           error
-	Resource      *v1alpha1.SupplyChainResource
-	StampedObject *unstructured.Unstructured
+	Err             error
+	SupplyChainName string
+	Resource        *v1alpha1.SupplyChainResource
+	StampedObject   *unstructured.Unstructured
 }
 
 func (e RetrieveOutputError) Error() string {
-	return fmt.Errorf("unable to retrieve outputs [%s] from stamped object [%s/%s] of type [%s] for resource [%s]: %w",
-		e.JsonPathExpression(), e.StampedObject.GetNamespace(), e.StampedObject.GetName(),
+	return fmt.Errorf("unable to retrieve outputs [%s] from stamped object [%s/%s] of type [%s] for resource [%s] in supply chain [%s]: %w",
+		e.JsonPathExpression(),
+		e.StampedObject.GetNamespace(),
+		e.StampedObject.GetName(),
 		utils.GetFullyQualifiedType(e.StampedObject),
-		e.Resource.Name, e.Err).Error()
+		e.Resource.Name,
+		e.SupplyChainName,
+		e.Err,
+	).Error()
 }
 
 type JsonPathErrorContext interface {

--- a/tests/kuttl/supplychain/templates-ytt-bad-params/02-assert.yaml
+++ b/tests/kuttl/supplychain/templates-ytt-bad-params/02-assert.yaml
@@ -25,7 +25,7 @@ status:
     - type: ResourcesSubmitted
       status: "False"
       reason: TemplateStampFailure
-      message: "unable to stamp object for resource [params]: unable to apply ytt template: ytt: Error: \n- key \"waciuma-com/quality\" not in struct\n    in <toplevel>\n      stdin.yml:8 |   best_name: #@ data.values.params[\"waciuma-com/quality\"]\n"
+      message: "unable to stamp object for resource [params] in supply chain [responsible-ops---templates-ytt-bad-params]: unable to apply ytt template: ytt: Error: \n- key \"waciuma-com/quality\" not in struct\n    in <toplevel>\n      stdin.yml:8 |   best_name: #@ data.values.params[\"waciuma-com/quality\"]\n"
     - type: Ready
       status: "False"
       reason: TemplateStampFailure


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Cartographer!

Also check the [PR guidelines] if you haven't already!
-->

[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Changes proposed by this PR


<!--
Add the story that is resolved or updated
`closes`/`fixes` or `updates` are valid here 
-->
closes #260 

<!--
Summarize your changes. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->


## Release Note
* When applying/creating an object fails, the owner's status will now report the resource and blueprint in which the failure occurred
<!--
Your PR title will be directly included in the release notes when it ships in
the next release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Add CreatorName field in Workload spec

Example notes:

* Operators can label stamped objects with the Workload's creator
* Creators can be contacted when interdepartmental issues arise 

If there are no additional notes necessary you may remove this entire section.
-->
[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above 
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
