### PR TITLE
Templates may use 'owner'

### DIFF
--- a/pkg/realizer/deliverable/component.go
+++ b/pkg/realizer/deliverable/component.go
@@ -92,6 +92,7 @@ func (r *resourceRealizer) Do(ctx context.Context, resource *v1alpha1.DeliveryRe
 	inputs := outputs.GenerateInputs(resource)
 	templatingContext := map[string]interface{}{
 		"deliverable": r.deliverable,
+		"owner":       r.deliverable,
 		"params":      templates.ParamsBuilder(template.GetDefaultParams(), r.deliveryParams, resource.Params, r.deliverable.Spec.Params),
 		"sources":     inputs.Sources,
 		"configs":     inputs.Configs,

--- a/pkg/realizer/workload/component.go
+++ b/pkg/realizer/workload/component.go
@@ -96,6 +96,7 @@ func (r *resourceRealizer) Do(ctx context.Context, resource *v1alpha1.SupplyChai
 	inputs := outputs.GenerateInputs(resource)
 	workloadTemplatingContext := map[string]interface{}{
 		"workload": r.workload,
+		"owner":    r.workload,
 		"params":   templates.ParamsBuilder(template.GetDefaultParams(), r.supplyChainParams, resource.Params, r.workload.Spec.Params),
 		"sources":  inputs.Sources,
 		"images":   inputs.Images,

--- a/site/content/docs/development/templating.md
+++ b/site/content/docs/development/templating.md
@@ -29,12 +29,16 @@ The entire owner resource is available for retrieving values. To use an owner va
  - **Simple template**: `$(<workload|deliverable>.<field-name>.(...))$`
  - **ytt**: `#@ data.values.<workload|deliverable>.<field-name>.(...)`
 
+The alias `owner` is available to replace workload and deliverable. This usage allows a template's use
+in both Supply Chain and Delivery.
+
 #### Owner Examples
 
 | Simple template | ytt | 
 | ----------- | ----------- | 
-| `$(workload.metadata.name)$`| `#@ data.values.workload.metadata.name` | 
+| `$(workload.spec.serviceAccountName)$`| `#@ data.values.workload.spec.serviceAccountName` | 
 | `$(deliverable.spec.source.url)$`| `#@ data.values.deliverable.spec.source.url` | 
+| `$(owner.metadata.name)$`| `#@ data.values.owner.metadata.name` | 
 
 ### Inputs
 The template specifies the inputs required in the blueprint.

--- a/tests/kuttl/delivery/delivery-templates-refer-to-owner/00-cluster-delivery.yaml
+++ b/tests/kuttl/delivery/delivery-templates-refer-to-owner/00-cluster-delivery.yaml
@@ -1,0 +1,58 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterDelivery
+metadata:
+  name: delivery---delivery-templates-refer-to-owner
+spec:
+  selector:
+    app.tanzu.vmware.com/deliverable-type: web---delivery-templates-refer-to-owner
+  resources:
+    - name: config-provider
+      templateRef:
+        kind: ClusterSourceTemplate
+        name: source---delivery-templates-refer-to-owner
+    - name: additional-info-provider
+      templateRef:
+        kind: ClusterSourceTemplate
+        name: additional---delivery-templates-refer-to-owner
+      params:
+        - name: uses-delivery
+          value: spiders
+        - name: uses-deliverable
+          default: some-value
+    - name: deployer
+      templateRef:
+        kind: ClusterDeploymentTemplate
+        name: app-deploy---delivery-templates-refer-to-owner
+      deployment:
+        resource: config-provider
+      sources:
+        - resource: additional-info-provider
+          name: additional
+    - name: sidecar-deployer
+      templateRef:
+        kind: ClusterDeploymentTemplate
+        name: sidecar-deploy---delivery-templates-refer-to-owner
+      deployment:
+        resource: deployer
+    - name: promoter
+      templateRef:
+        kind: ClusterTemplate
+        name: git-merge---delivery-templates-refer-to-owner
+      sources:
+      - resource: sidecar-deployer
+        name: sidecar-deployer

--- a/tests/kuttl/delivery/delivery-templates-refer-to-owner/00-service-account.yaml
+++ b/tests/kuttl/delivery/delivery-templates-refer-to-owner/00-service-account.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-service-account
+secrets:
+  - name: my-service-account-secret
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-service-account-secret
+  annotations:
+    kubernetes.io/service-account.name: my-service-account
+data:
+  token: "ZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNklubFNWM1YxVDNSRldESnZVRE4wTUd0R1EzQmlVVlJOVWtkMFNGb3RYMGh2VUhKYU1FRnVOR0Y0WlRBaWZRLmV5SnBjM01pT2lKcmRXSmxjbTVsZEdWekwzTmxjblpwWTJWaFkyTnZkVzUwSWl3aWEzVmlaWEp1WlhSbGN5NXBieTl6WlhKMmFXTmxZV05qYjNWdWRDOXVZVzFsYzNCaFkyVWlPaUprWldaaGRXeDBJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpXTnlaWFF1Ym1GdFpTSTZJbTE1TFhOaExYUnZhMlZ1TFd4dVkzRndJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpYSjJhV05sTFdGalkyOTFiblF1Ym1GdFpTSTZJbTE1TFhOaElpd2lhM1ZpWlhKdVpYUmxjeTVwYnk5elpYSjJhV05sWVdOamIzVnVkQzl6WlhKMmFXTmxMV0ZqWTI5MWJuUXVkV2xrSWpvaU9HSXhNV1V3WldNdFlURTVOeTAwWVdNeUxXRmpORFF0T0RjelpHSmpOVE13TkdKbElpd2ljM1ZpSWpvaWMzbHpkR1Z0T25ObGNuWnBZMlZoWTJOdmRXNTBPbVJsWm1GMWJIUTZiWGt0YzJFaWZRLmplMzRsZ3hpTUtnd0QxUGFhY19UMUZNWHdXWENCZmhjcVhQMEE2VUV2T0F6ek9xWGhpUUdGN2poY3RSeFhmUVFJVEs0Q2tkVmZ0YW5SUjNPRUROTUxVMVBXNXVsV3htVTZTYkMzdmZKT3ozLVJPX3BOVkNmVW8tZURpblN1Wm53bjNzMjNjZU9KM3IzYk04cnBrMHZZZFgyRVlQRGItMnd4cjIzZ1RxUjVxZU5ULW11cS1qYktXVE8wYnRYVl9wVHNjTnFXUkZIVzJBVTVHYVBpbmNWVXg1bXExLXN0SFdOOGtjTG96OF96S2RnUnJGYV92clFjb3NWZzZCRW5MSEt2NW1fVEhaR3AybU8wYmtIV3J1Q2xEUDdLc0tMOFVaZWxvTDN4Y3dQa000VlBBb2V0bDl5MzlvUi1KbWh3RUlIcS1hX3BzaVh5WE9EQU44STcybEZpUSU="
+type: kubernetes.io/service-account-token

--- a/tests/kuttl/delivery/delivery-templates-refer-to-owner/00-templates.yaml
+++ b/tests/kuttl/delivery/delivery-templates-refer-to-owner/00-templates.yaml
@@ -1,0 +1,115 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterSourceTemplate
+metadata:
+  name: source---delivery-templates-refer-to-owner
+spec:
+  urlPath: .spec.value.url
+  revisionPath: .spec.value.ref
+
+  template:
+    apiVersion: test.run/v1alpha1
+    kind: Test
+    metadata:
+      name: $(owner.metadata.name)$
+    spec:
+      value:
+        url: $(owner.spec.source.git.url)$
+        ref: $(owner.spec.source.git.ref)$
+
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterSourceTemplate
+metadata:
+  name: additional---delivery-templates-refer-to-owner
+spec:
+  urlPath: .spec.value.creepy
+  revisionPath: .spec.value.spooky
+
+  params:
+    - name: uses-delivery
+      default: clowns
+    - name: uses-default
+      default: snakes
+    - name: uses-deliverable
+      default: monster
+
+  template:
+    apiVersion: test.run/v1alpha1
+    kind: Test
+    metadata:
+      name: $(owner.metadata.name)$-additional
+    spec:
+      value:
+        creepy: $(params.uses-delivery)$
+        scary: $(params.uses-default)$
+        spooky: $(params.uses-deliverable)$
+
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterDeploymentTemplate
+metadata:
+  name: app-deploy---delivery-templates-refer-to-owner
+spec:
+  observedMatches:
+    - input: "spec.value.some-key"
+      output: "spec.value.duplicate-of-some-key"
+  template:
+    apiVersion: test.run/v1alpha1
+    kind: Test
+    metadata:
+      name: $(owner.metadata.name)$-1
+    spec:
+      value:
+        some-key: $(deployment.url)$
+        duplicate-of-some-key: $(deployment.url)$
+
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterDeploymentTemplate
+metadata:
+  name: sidecar-deploy---delivery-templates-refer-to-owner
+spec:
+  observedMatches:
+    - input: "spec.value.some-key"
+      output: "spec.value.duplicate-of-some-key"
+  template:
+    apiVersion: test.run/v1alpha1
+    kind: Test
+    metadata:
+      name: $(owner.metadata.name)$-sidecar
+    spec:
+      value:
+        some-key: $(deployment.url)$
+        duplicate-of-some-key: $(deployment.url)$
+
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: git-merge---delivery-templates-refer-to-owner
+spec:
+  ytt: |
+    #@ load("@ytt:data", "data")
+
+    apiVersion: test.run/v1alpha1
+    kind: Test
+    metadata:
+      name: #@ data.values.owner.metadata.name + "-merge"
+    spec:
+      value:
+        merge-key: #@ data.values.source.url

--- a/tests/kuttl/delivery/delivery-templates-refer-to-owner/01-assert.yaml
+++ b/tests/kuttl/delivery/delivery-templates-refer-to-owner/01-assert.yaml
@@ -1,0 +1,84 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: test.run/v1alpha1
+kind: Test
+metadata:
+  name: my-app
+spec:
+  value:
+    url: https://github.com/ekcasey/hello-world-ops
+    ref:
+      branch: prod
+
+---
+apiVersion: test.run/v1alpha1
+kind: Test
+metadata:
+  name: my-app-additional
+spec:
+  value:
+    creepy: spiders
+    scary: snakes
+    spooky: ghosts
+
+---
+apiVersion: test.run/v1alpha1
+kind: Test
+metadata:
+  name: my-app-1
+spec:
+  value:
+    some-key: https://github.com/ekcasey/hello-world-ops
+    duplicate-of-some-key: https://github.com/ekcasey/hello-world-ops
+
+---
+apiVersion: test.run/v1alpha1
+kind: Test
+metadata:
+  name: my-app-sidecar
+spec:
+  value:
+    some-key: https://github.com/ekcasey/hello-world-ops
+    duplicate-of-some-key: https://github.com/ekcasey/hello-world-ops
+
+---
+apiVersion: test.run/v1alpha1
+kind: Test
+metadata:
+  name: my-app-merge
+spec:
+  value:
+    merge-key: https://github.com/ekcasey/hello-world-ops
+
+---
+apiVersion: carto.run/v1alpha1
+kind: Deliverable
+metadata:
+  name: my-app
+status:
+  conditions:
+    - type: DeliveryReady
+      status: "True"
+      reason: Ready
+    - type: ResourcesSubmitted
+      status: "True"
+      reason: ResourceSubmissionComplete
+    - type: Ready
+      status: "True"
+      reason: Ready
+  deliveryRef:
+    name: delivery---delivery-templates-refer-to-owner
+    kind: ClusterDelivery

--- a/tests/kuttl/delivery/delivery-templates-refer-to-owner/01-deliverable.yaml
+++ b/tests/kuttl/delivery/delivery-templates-refer-to-owner/01-deliverable.yaml
@@ -1,0 +1,31 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: carto.run/v1alpha1
+kind: Deliverable
+metadata:
+  name: my-app
+  labels:
+    app.tanzu.vmware.com/deliverable-type: web---delivery-templates-refer-to-owner
+spec:
+  serviceAccountName: my-service-account
+  source:
+    git:
+      url: https://github.com/ekcasey/hello-world-ops
+      ref:
+        branch: prod
+  params:
+    - name: uses-deliverable
+      value: ghosts

--- a/tests/kuttl/supplychain/templates-refer-to-owner/00-service-account.yaml
+++ b/tests/kuttl/supplychain/templates-refer-to-owner/00-service-account.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-service-account
+secrets:
+  - name: my-service-account-secret
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-service-account-secret
+  annotations:
+    kubernetes.io/service-account.name: my-service-account
+data:
+  token: "ZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNklubFNWM1YxVDNSRldESnZVRE4wTUd0R1EzQmlVVlJOVWtkMFNGb3RYMGh2VUhKYU1FRnVOR0Y0WlRBaWZRLmV5SnBjM01pT2lKcmRXSmxjbTVsZEdWekwzTmxjblpwWTJWaFkyTnZkVzUwSWl3aWEzVmlaWEp1WlhSbGN5NXBieTl6WlhKMmFXTmxZV05qYjNWdWRDOXVZVzFsYzNCaFkyVWlPaUprWldaaGRXeDBJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpXTnlaWFF1Ym1GdFpTSTZJbTE1TFhOaExYUnZhMlZ1TFd4dVkzRndJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpYSjJhV05sTFdGalkyOTFiblF1Ym1GdFpTSTZJbTE1TFhOaElpd2lhM1ZpWlhKdVpYUmxjeTVwYnk5elpYSjJhV05sWVdOamIzVnVkQzl6WlhKMmFXTmxMV0ZqWTI5MWJuUXVkV2xrSWpvaU9HSXhNV1V3WldNdFlURTVOeTAwWVdNeUxXRmpORFF0T0RjelpHSmpOVE13TkdKbElpd2ljM1ZpSWpvaWMzbHpkR1Z0T25ObGNuWnBZMlZoWTJOdmRXNTBPbVJsWm1GMWJIUTZiWGt0YzJFaWZRLmplMzRsZ3hpTUtnd0QxUGFhY19UMUZNWHdXWENCZmhjcVhQMEE2VUV2T0F6ek9xWGhpUUdGN2poY3RSeFhmUVFJVEs0Q2tkVmZ0YW5SUjNPRUROTUxVMVBXNXVsV3htVTZTYkMzdmZKT3ozLVJPX3BOVkNmVW8tZURpblN1Wm53bjNzMjNjZU9KM3IzYk04cnBrMHZZZFgyRVlQRGItMnd4cjIzZ1RxUjVxZU5ULW11cS1qYktXVE8wYnRYVl9wVHNjTnFXUkZIVzJBVTVHYVBpbmNWVXg1bXExLXN0SFdOOGtjTG96OF96S2RnUnJGYV92clFjb3NWZzZCRW5MSEt2NW1fVEhaR3AybU8wYmtIV3J1Q2xEUDdLc0tMOFVaZWxvTDN4Y3dQa000VlBBb2V0bDl5MzlvUi1KbWh3RUlIcS1hX3BzaVh5WE9EQU44STcybEZpUSU="
+type: kubernetes.io/service-account-token

--- a/tests/kuttl/supplychain/templates-refer-to-owner/00-templates.yaml
+++ b/tests/kuttl/supplychain/templates-refer-to-owner/00-templates.yaml
@@ -1,0 +1,71 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: carto.run/v1alpha1
+kind: ClusterSourceTemplate
+metadata:
+  name: git-template---templates-refer-to-owner
+spec:
+  urlPath: .data.workload_git_url
+  revisionPath: .data.workload_git_ref_branch
+  template:
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: test-configmap-source
+    data:
+      workload_git_url: $(owner.spec.source.git.url)$
+      workload_name: $(owner.metadata.name)$
+      workload_git_ref_branch: $(owner.spec.source.git.ref.branch)$
+      workload_services_first_kind: $(owner.spec.serviceClaims[0].ref.kind)$
+      workload_env: $(owner.spec.env[?(@.name=="SPRING_PROFILES_ACTIVE")].value)$
+      workload_build_env: $(owner.spec.build.env[?(@.name=="SOME_BUILD_ENV")].value)$
+      workload_resources_requests_cpu: $(owner.spec.resources.requests.cpu)$
+
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterSourceTemplate
+metadata:
+  name: deliverable-list---templates-refer-to-owner
+spec:
+  urlPath: .spec.value
+  revisionPath: .metadata.name
+  template:
+    apiVersion: test.run/v1alpha1
+    kind: Test
+    metadata:
+      name: test-deliverable-list
+    spec:
+      value:
+        env: $(owner.spec.env)$
+
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterSourceTemplate
+metadata:
+  name: deliverable-object---templates-refer-to-owner
+spec:
+  urlPath: .spec.value
+  revisionPath: .metadata.name
+
+  ytt: |
+    #@ load("@ytt:data", "data")
+
+    apiVersion: test.run/v1alpha1
+    kind: Test
+    metadata:
+      name: test-deliverable-object
+    spec:
+      value:
+        git: #@ data.values.owner.spec.source.git

--- a/tests/kuttl/supplychain/templates-refer-to-owner/01-supply-chain.yaml
+++ b/tests/kuttl/supplychain/templates-refer-to-owner/01-supply-chain.yaml
@@ -1,0 +1,36 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: carto.run/v1alpha1
+kind: ClusterSupplyChain
+metadata:
+  name: responsible-ops---templates-refer-to-owner
+spec:
+  selector:
+    integration-test: "templates-refer-to-owner"
+  resources:
+    - name: source-provider
+      templateRef:
+        kind: ClusterSourceTemplate
+        name: git-template---templates-refer-to-owner
+
+    - name: another-source-provider
+      templateRef:
+        kind: ClusterSourceTemplate
+        name: deliverable-list---templates-refer-to-owner
+
+    - name: yet-another-source-provider
+      templateRef:
+        kind: ClusterSourceTemplate
+        name: deliverable-object---templates-refer-to-owner

--- a/tests/kuttl/supplychain/templates-refer-to-owner/02-assert.yaml
+++ b/tests/kuttl/supplychain/templates-refer-to-owner/02-assert.yaml
@@ -1,0 +1,78 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap-source
+  labels:
+    carto.run/workload-name: petclinic
+    carto.run/cluster-supply-chain-name: responsible-ops---templates-refer-to-owner
+    carto.run/resource-name: source-provider
+    carto.run/cluster-template-name: git-template---templates-refer-to-owner
+  ownerReferences:
+    - apiVersion: carto.run/v1alpha1
+      kind: Workload
+      name: petclinic
+data:
+  workload_git_url: https://github.com/spring-projects/spring-petclinic.git
+  workload_name: petclinic
+  workload_git_ref_branch: main
+  workload_services_first_kind: RabbitMQ
+  workload_env: mysql
+  workload_build_env: foo
+  workload_resources_requests_cpu: 250m
+
+---
+apiVersion: test.run/v1alpha1
+kind: Test
+metadata:
+  name: test-deliverable-list
+spec:
+  value:
+    env:
+      - name: SPRING_PROFILES_ACTIVE
+        value: mysql
+
+---
+apiVersion: test.run/v1alpha1
+kind: Test
+metadata:
+  name: test-deliverable-object
+spec:
+  value:
+    git:
+      url: https://github.com/spring-projects/spring-petclinic.git
+      ref:
+        branch: main
+
+---
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  name: petclinic
+status:
+  conditions:
+    - type: SupplyChainReady
+      status: "True"
+      reason: Ready
+    - type: ResourcesSubmitted
+      status: "True"
+      reason: ResourceSubmissionComplete
+    - type: Ready
+      status: "True"
+      reason: Ready
+  supplyChainRef:
+    name: responsible-ops---templates-refer-to-owner
+    kind: ClusterSupplyChain

--- a/tests/kuttl/supplychain/templates-refer-to-owner/02-workload.yaml
+++ b/tests/kuttl/supplychain/templates-refer-to-owner/02-workload.yaml
@@ -1,0 +1,62 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  name: petclinic
+  labels:
+    integration-test: "templates-refer-to-owner"
+spec:
+  serviceAccountName: my-service-account
+  params:
+    - name: waciuma-com/quality
+      value: beta
+    - name: waciuma-com/java-version
+      value: 11
+
+  source:
+    git:
+      url: https://github.com/spring-projects/spring-petclinic.git
+      ref:
+        branch: main
+
+  serviceClaims:
+    - name: broker
+      ref:
+        apiVersion: services.tanzu.vmware.com/v1alpha1
+        kind: RabbitMQ
+        name: my-broker
+    - name: database
+      ref:
+        apiVersion: services.tanzu.vmware.com/v1alpha1
+        kind: MySQL
+        name: my-database
+
+  env:
+    - name: SPRING_PROFILES_ACTIVE
+      value: mysql
+
+  build:
+    env:
+      - name: SOME_BUILD_ENV
+        value: foo
+
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "250m"
+    limits:
+      memory: "2Gi"
+      cpu: "500m"


### PR DESCRIPTION
Templates may use 'owner' to refer to workload or deliverable.

---
name: Templates may use 'owner'
about: Templates may use 'owner' to refer to workload or deliverable.

---
<!--
Thanks for submitting a pull request to Cartographer!

Also check the [PR guidelines] if you haven't already!
-->

[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Changes proposed by this PR

<!--
Add the story that is resolved or updated
`closes`/`fixes` or `updates` are valid here 
-->
closes #268 

<!--
Summarize your changes. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->


## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Add CreatorName field in Workload spec

Example notes:

* Operators can label stamped objects with the Workload's creator
* Creators can be contacted when interdepartmental issues arise 

If there are no additional notes necessary you may remove this entire section.
-->
[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

* Templates may use the alias 'owner' to refer to workload or deliverable.

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above 
- [x] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
