### PR TITLE
Fix changelog in release notes to track from latest release

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -216,7 +216,6 @@ git_previous_version() {
 
         git tag --sort=-v:refname -l |
                 grep -A30 $version_filter |
-                tail -n +2 |
                 grep -E '^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$' |
                 head -n1
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Cartographer!

Also check the [PR guidelines] if you haven't already!
-->

[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Changes proposed by this PR

<!--
Add the story that is resolved or updated
`closes`/`fixes` or `updates` are valid here 
-->
The release workflow generates a changelog that is supposed to list every commit from the last release. Right now it does not work correctly and prints commits older than the latest release. This change fixes that.

<!--
Summarize your changes. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->




<!--
Your PR title will be directly included in the release notes when it ships in
the next release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Add CreatorName field in Workload spec

Example notes:

* Operators can label stamped objects with the Workload's creator
* Creators can be contacted when interdepartmental issues arise 

If there are no additional notes necessary you may remove this entire section.
-->
[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [ ] Filled in the [Release Note](#Release-Note) section above 
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
