### PR TITLE
hack: bump ytt version

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -25,8 +25,8 @@ readonly REGISTRY=${REGISTRY:-"$($ROOT/hack/ip.py):5000"}
 readonly BUNDLE=${BUNDLE:-$REGISTRY/cartographer-bundle}
 readonly RELEASE_DATE=${RELEASE_DATE:-$(TZ=UTC date +"%Y-%m-%dT%H:%M:%SZ")}
 
-readonly YTT_VERSION=0.38.0
-readonly YTT_CHECKSUM=2ca800c561464e0b252e5ee5cacff6aa53831e65e2fb9a09cf388d764013c40d
+readonly YTT_VERSION=0.39.0
+readonly YTT_CHECKSUM=7a472b8c62bfec5c12586bb39065beda42c6fe43cf24271275e4dbc0a04acb8b
 
 main() {
         readonly RELEASE_VERSION="v0.0.0-dev"


### PR DESCRIPTION

## Changes proposed by this PR

a new version of YTT has been released (see https://github.com/vmware-tanzu/carvel-ytt/releases/tag/v0.39.0), thus, bump on our side.

closes #580 


## Release Note

* Bump YTT to [0.39.0](https://github.com/vmware-tanzu/carvel-ytt/releases/tag/v0.39.0)

## PR Checklist

- [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [ ] Removed non-atomic or `wip` commits
- [ ] Filled in the [Release Note](#Release-Note) section above 
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
