### PR TITLE
packaging: improve kapp rules (remove phantom secret annotation diffs)

### DIFF
--- a/packaging/objects/kapp-secret-ignore.yaml
+++ b/packaging/objects/kapp-secret-ignore.yaml
@@ -22,7 +22,8 @@ rebaseRules:
   - apiVersionKindMatcher:
       apiVersion: v1
       kind: Secret
-- path: [metadata,annotations]
+diffAgainstLastAppliedFieldExclusionRules:
+- path: [metadata, annotations]
   type: copy
   sources: [existing]
   resourceMatchers:


### PR DESCRIPTION
## Changes proposed by this PR

- change `rebaseRule` for `metadata.annotations` (for Secret objects) to `diffAgainstLastAppliedFieldExclusionRules`

prior to this commit, with the use of rebaseRules for
`metadata.annotations`, we'd end up always stripping out the annotations
that get set by `kapp` itself when performing the evaluation of the diff
against the live state, which meant that we'd end up seeing `kapp`
always producing in its changeset an addition of its own annotations:

```
@@ update secret/private-registry-credentials (v1) namespace: cartographer-sys
  ...
  5,  5     annotations:
      6 +     kapp.k14s.io/original: '{"apiVersion":"v1","data":{".dockerconfion"}'
      7 +     kapp.k14s.io/original-diff-md5: 58e0494c51d30eb3494f7c9198986bb9

@@ update secret/cartographer-webhook (v1) namespace: cartographer-system @@
  ...
 15, 15       cert-manager.io/uri-sans: ""
     16 +     kapp.k14s.io/original: '{"apiVersion":"v1","kind":"Secret","meta
     17 +     kapp.k14s.io/original-diff-md5: 58e0494c51d30eb3494f7c9198986bb9
 16, 18     creationTimestamp: "2022-02-04T15:47:33Z"
 17, 19     labels:
```

with the use of diffAgainstLastAppliedFieldExclusionRules (see [1]) we can avoid
that while preserving the intention of having whatever annotations that
other controllers have already set staying there.

[1]: https://carvel.dev/kapp/docs/v0.45.0/config/#diffagainstlastappliedfieldexclusionrules

closes #581


## Acceptance

To verify that we indeed fix the behavior:

1. prior to this PR, update `packaging/package-install.yaml` to have a `syncPeriod` that's very frequent (e.g., 5s), then `./hack/setup.sh cluster cartographer` 
2. observe high number of configmaps (`cartographer.carto.run.0.0.0-dev-ctrl-change-<blah>`)
3. checkout the commit included here
4. install new package (`./hack/setup.sh cartographer`)
5. observe that we don't have new changes anymore


## Release Note

- On Package-based installation, reduce number of kapp diffs for Secrets that get annotated by other controllers.

## PR Checklist

- [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [ ] Removed non-atomic or `wip` commits
- [ ] Filled in the [Release Note](#Release-Note) section above 
- ~Modified the docs to match changes~
