### PR TITLE
packaging: add overlay for removing obj statuses

### DIFF
--- a/packaging/overlays/strip-status.yaml
+++ b/packaging/overlays/strip-status.yaml
@@ -1,0 +1,20 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.all, expects="0+"
+---
+#@overlay/match missing_ok=True
+status: #@overlay/remove


### PR DESCRIPTION


## Changes proposed by this PR

- Include an overlay to strip out statuses of the objects before submission via kapp

the objects that are submitted during the installation of cartographer
currently include a `.status` for the CRD object, which shouldn't really
exist - newer versions of `kapp` do include an internal rule (like the
one introduced in the commit) that ignores that, but given that some
folks might be installing cartographer with older versions, it's useful
to have that rule explicitly set here.

closes #581 


## Release Note

- Improve packaging to remove status from CRD objects.

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [ ] Removed non-atomic or `wip` commits
- [ ] Filled in the [Release Note](#Release-Note) section above 
- ~[ ] Modified the docs to match changes~