### PR TITLE
615 reproduction of crashing when using verbose logging.

### DIFF
--- a/pkg/realizer/runnable/realizer.go
+++ b/pkg/realizer/runnable/realizer.go
@@ -122,7 +122,7 @@ func (p *runnableRealizer) Realize(ctx context.Context, runnable *v1alpha1.Runna
 		log.Error(err, "failed to cleanup runnable stamped objects")
 	}
 
-	outputs, evaluatedStampedObject, err := template.GetOutput(allRunnableStampedObjects)
+	outputs, _, err := template.GetOutput(allRunnableStampedObjects)
 	if err != nil {
 		for _, obj := range allRunnableStampedObjects {
 			log.V(logger.DEBUG).Info("failed to retrieve output from any object", "considered", obj)
@@ -134,7 +134,7 @@ func (p *runnableRealizer) Realize(ctx context.Context, runnable *v1alpha1.Runna
 			TemplateRef:   &runnable.Spec.RunTemplateRef,
 		}
 	}
-	log.V(logger.DEBUG).Info("retrieved output from stamped object", "stamped object", evaluatedStampedObject)
+	log.V(logger.DEBUG).Info("retrieved output from stamped object", "stamped object")
 
 	if len(outputs) == 0 {
 		log.V(logger.DEBUG).Info("no outputs retrieved, getting outputs from runnable.Status.Outputs")

--- a/tests/integration/runnable/runnable_suite_test.go
+++ b/tests/integration/runnable/runnable_suite_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
+	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -79,7 +80,12 @@ var _ = BeforeSuite(func() {
 
 	controllerBuffer = gbytes.NewBuffer()
 	controllerOutput := io.MultiWriter(controllerBuffer, GinkgoWriter)
-	logger := zap.New(zap.WriteTo(controllerOutput))
+
+	// Set up for debug
+	logger := zap.New(zap.UseFlagOptions(&zap.Options{
+		Level: zapcore.DebugLevel,
+		DestWriter: controllerOutput,
+	}))
 
 	controllerError = make(chan error)
 


### PR DESCRIPTION
Reproduce error in https://github.com/vmware-tanzu/cartographer/issues/615

See the commit logs.