### PR TITLE
Switch cluster-delivery-name to delivery-name

### DIFF
--- a/pkg/realizer/deliverable/component.go
+++ b/pkg/realizer/deliverable/component.go
@@ -99,7 +99,7 @@ func (r *resourceRealizer) Do(ctx context.Context, resource *v1alpha1.DeliveryRe
 	labels := map[string]string{
 		"carto.run/deliverable-name":      r.deliverable.Name,
 		"carto.run/deliverable-namespace": r.deliverable.Namespace,
-		"carto.run/cluster-delivery-name": deliveryName,
+		"carto.run/delivery-name":         deliveryName,
 		"carto.run/resource-name":         resource.Name,
 		"carto.run/template-kind":         template.GetKind(),
 		"carto.run/cluster-template-name": template.GetName(),

--- a/pkg/realizer/deliverable/component_test.go
+++ b/pkg/realizer/deliverable/component_test.go
@@ -190,7 +190,7 @@ var _ = Describe("Resource", func() {
 				}))
 				Expect(stampedObject.Object["data"]).To(Equal(map[string]interface{}{"player_current_lives": "some-url", "some_other_info": "some-revision"}))
 				Expect(metadataValues["labels"]).To(Equal(map[string]interface{}{
-					"carto.run/cluster-delivery-name": "delivery-name",
+					"carto.run/delivery-name":         "delivery-name",
 					"carto.run/resource-name":         "resource-1",
 					"carto.run/cluster-template-name": "source-template-1",
 					"carto.run/deliverable-name":      "",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Cartographer!

Also check the [PR guidelines] if you haven't already!
-->

[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Changes proposed by this PR

<!--
Add the story that is resolved or updated
`closes`/`fixes` or `updates` are valid here 
-->
closes #636 

<!--
Summarize your changes. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->


## Release Note

Changes label key to use delivery-name instead of cluster-delivery-name

<!--
Your PR title will be directly included in the release notes when it ships in
the next release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Add CreatorName field in Workload spec

Example notes:

* Operators can label stamped objects with the Workload's creator
* Creators can be contacted when interdepartmental issues arise 

If there are no additional notes necessary you may remove this entire section.
-->
[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [X] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [X] Removed non-atomic or `wip` commits
- [X] Filled in the [Release Note](#Release-Note) section above 
- ~~[ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->~~
