### PR TITLE
Remove error log when resource is deleted

### DIFF
--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -393,7 +393,6 @@ func (r *repository) getObject(ctx context.Context, name string, namespace strin
 	)
 	if err != nil {
 		namespacedName := getNamespacedName(name, namespace)
-		log.Error(err, "failed to get object from api server", "object", namespacedName)
 		return fmt.Errorf("failed to get object [%s] from api server: %w", namespacedName, err)
 	}
 

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -634,10 +634,12 @@ spec:
 					)
 					cl.GetReturns(apiError)
 				})
-				It("returns a nil result without error", func() {
+				It("returns a nil result without error and without logging an error", func() {
 					delivery, err := repo.GetDelivery(ctx, "my-delivery")
 					Expect(err).NotTo(HaveOccurred())
 					Expect(delivery).To(BeNil())
+
+					Expect(out.Contents()).To(BeEmpty())
 				})
 			})
 
@@ -996,10 +998,12 @@ spec:
 			})
 
 			Context("workload doesnt exist", func() {
-				It("returns nil workload", func() {
+				It("returns nil workload without logging an error", func() {
 					workload, err := repo.GetWorkload(ctx, "workload-that-does-not-exist-name", "workload-namespace")
 					Expect(err).NotTo(HaveOccurred())
 					Expect(workload).To(BeNil())
+
+					Expect(out.Contents()).To(BeEmpty())
 				})
 			})
 		})
@@ -1022,10 +1026,12 @@ spec:
 			})
 
 			Context("deliverable doesnt exist", func() {
-				It("returns nil deliverable", func() {
+				It("returns nil deliverable without logging an error", func() {
 					deliverable, err := repo.GetDeliverable(ctx, "deliverable-that-does-not-exist-name", "deliverable-namespace")
 					Expect(err).NotTo(HaveOccurred())
 					Expect(deliverable).To(BeNil())
+
+					Expect(out.Contents()).To(BeEmpty())
 				})
 			})
 		})
@@ -1048,10 +1054,12 @@ spec:
 			})
 
 			Context("runnable doesnt exist", func() {
-				It("returns nil runnable", func() {
+				It("returns nil runnable without logging an error", func() {
 					runnable, err := repo.GetRunnable(ctx, "runnable-that-does-not-exist-name", "runnable-namespace")
 					Expect(err).NotTo(HaveOccurred())
 					Expect(runnable).To(BeNil())
+
+					Expect(out.Contents()).To(BeEmpty())
 				})
 			})
 		})
@@ -1073,10 +1081,12 @@ spec:
 			})
 
 			Context("supply chain doesnt exist", func() {
-				It("returns no error", func() {
+				It("returns no error without logging an error", func() {
 					sc, err := repo.GetSupplyChain(ctx, "sc-that-does-not-exist-name")
 					Expect(err).ToNot(HaveOccurred())
 					Expect(sc).To(BeNil())
+
+					Expect(out.Contents()).To(BeEmpty())
 				})
 			})
 		})


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Cartographer!

Also check the [PR guidelines] if you haven't already!
-->

[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Changes proposed by this PR

Controller no longer logs an error when a resource has been deleted.
<!--
Add the story that is resolved or updated
`closes`/`fixes` or `updates` are valid here 
-->
closes #586 

<!--
Summarize your changes. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->


## Release Note

Controller no longer logs an error when a resource has been deleted.
<!--
Your PR title will be directly included in the release notes when it ships in
the next release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Add CreatorName field in Workload spec

Example notes:

* Operators can label stamped objects with the Workload's creator
* Creators can be contacted when interdepartmental issues arise 

If there are no additional notes necessary you may remove this entire section.
-->
[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above 
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
