### PR TITLE
Switch from goimports to gci

### DIFF
--- a/lint-config.yaml
+++ b/lint-config.yaml
@@ -14,11 +14,11 @@
 
 linters:
   enable:
-    - goimports
+    - gci
     - govet
 
 linters-settings:
-  goimports:
+  gci:
     local-prefixes: github.com/vmware-tanzu/cartographer
   govet:
     disable:

--- a/pkg/realizer/deliverable/component_test.go
+++ b/pkg/realizer/deliverable/component_test.go
@@ -27,10 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/vmware-tanzu/cartographer/pkg/repository"
-
 	"github.com/vmware-tanzu/cartographer/pkg/apis/v1alpha1"
 	realizer "github.com/vmware-tanzu/cartographer/pkg/realizer/deliverable"
+	"github.com/vmware-tanzu/cartographer/pkg/repository"
 	"github.com/vmware-tanzu/cartographer/pkg/repository/repositoryfakes"
 	"github.com/vmware-tanzu/cartographer/pkg/templates"
 )

--- a/pkg/templates/cluster_run_template_test.go
+++ b/pkg/templates/cluster_run_template_test.go
@@ -21,9 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
-	"github.com/vmware-tanzu/cartographer/pkg/templates"
-
 	"github.com/vmware-tanzu/cartographer/pkg/apis/v1alpha1"
+	"github.com/vmware-tanzu/cartographer/pkg/templates"
 	"github.com/vmware-tanzu/cartographer/pkg/utils"
 )
 

--- a/pkg/templates/stamper_test.go
+++ b/pkg/templates/stamper_test.go
@@ -18,13 +18,12 @@ import (
 	"context"
 	"os"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	v1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"

--- a/tests/integration/delivery/deliverable_reconciler_test.go
+++ b/tests/integration/delivery/deliverable_reconciler_test.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -112,7 +111,7 @@ var _ = Describe("DeliverableReconciler", func() {
 		testToUpdate.Status.Conditions = append(testToUpdate.Status.Conditions, metav1.Condition{
 			Type:               conditionType,
 			Status:             conditionStatus,
-			LastTransitionTime: v1.Now(),
+			LastTransitionTime: metav1.Now(),
 			Reason:             "SetByTest",
 			Message:            "",
 		})
@@ -123,8 +122,8 @@ var _ = Describe("DeliverableReconciler", func() {
 
 	var newClusterDelivery = func(name string, selector map[string]string) *v1alpha1.ClusterDelivery {
 		return &v1alpha1.ClusterDelivery{
-			TypeMeta: v1.TypeMeta{},
-			ObjectMeta: v1.ObjectMeta{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 			Spec: v1alpha1.DeliverySpec{
@@ -230,7 +229,7 @@ var _ = Describe("DeliverableReconciler", func() {
 		})
 
 		It("does not update the lastTransitionTime on subsequent reconciliation if the status does not change", func() {
-			var lastConditions []v1.Condition
+			var lastConditions []metav1.Condition
 
 			Eventually(func() bool {
 				deliverable := &v1alpha1.Deliverable{}
@@ -252,8 +251,8 @@ var _ = Describe("DeliverableReconciler", func() {
 		Context("and reconciliation will end in an unknown status", func() {
 			BeforeEach(func() {
 				template := &v1alpha1.ClusterSourceTemplate{
-					TypeMeta: v1.TypeMeta{},
-					ObjectMeta: v1.ObjectMeta{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
 						Name: "proper-template-bob",
 					},
 					Spec: v1alpha1.SourceTemplateSpec{
@@ -285,7 +284,7 @@ var _ = Describe("DeliverableReconciler", func() {
 			})
 
 			It("does not error if the reconciliation ends in an unknown status", func() {
-				Eventually(func() []v1.Condition {
+				Eventually(func() []metav1.Condition {
 					obj := &v1alpha1.Deliverable{}
 					err := c.Get(ctx, client.ObjectKey{Name: "deliverable-bob", Namespace: testNS}, obj)
 					Expect(err).NotTo(HaveOccurred())
@@ -295,12 +294,12 @@ var _ = Describe("DeliverableReconciler", func() {
 					MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal("ResourcesSubmitted"),
 						"Reason": Equal("MissingValueAtPath"),
-						"Status": Equal(v1.ConditionStatus("Unknown")),
+						"Status": Equal(metav1.ConditionStatus("Unknown")),
 					}),
 					MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal("Ready"),
 						"Reason": Equal("MissingValueAtPath"),
-						"Status": Equal(v1.ConditionStatus("Unknown")),
+						"Status": Equal(metav1.ConditionStatus("Unknown")),
 					}),
 				))
 				Expect(controllerBuffer).NotTo(gbytes.Say("Reconciler error.*unable to retrieve outputs from stamped object for resource"))

--- a/tests/integration/delivery/delivery_test.go
+++ b/tests/integration/delivery/delivery_test.go
@@ -18,11 +18,10 @@ import (
 	"context"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
* gci automatically formats our imports into
  three groupings correctly

Co-authored-by: Marty Spiewak <mspiewak@vmware.com>

<!--
Thanks for submitting a pull request to Cartographer!

Also check the [PR guidelines] if you haven't already!
-->

[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Changes proposed by this PR

goimports is not able to format our imports correctly when there are already multiple import groups, whereas gci is able to format them correctly regardless of how they are currently structured.

<!--
Add the story that is resolved or updated
`closes`/`fixes` or `updates` are valid here 
-->


<!--
Summarize your changes. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->




<!--
Your PR title will be directly included in the release notes when it ships in
the next release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Add CreatorName field in Workload spec

Example notes:

* Operators can label stamped objects with the Workload's creator
* Creators can be contacted when interdepartmental issues arise 

If there are no additional notes necessary you may remove this entire section.
-->
[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [ ] Removed non-atomic or `wip` commits
- [ ] Filled in the [Release Note](#Release-Note) section above 
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
