### PR TITLE
Write Service object as a YAML fragment in example

### DIFF
--- a/examples/gitwriter-sc/app-operator/config-service.yaml
+++ b/examples/gitwriter-sc/app-operator/config-service.yaml
@@ -21,35 +21,38 @@ spec:
 
   ytt: |
     #@ load("@ytt:data", "data")
+    #@ load("@ytt:yaml", "yaml")
+    
+    #@ def service():
+    apiVersion: serving.knative.dev/v1
+    kind: Service
+    metadata:
+      name: #@ data.values.workload.metadata.name
+      labels:
+        #@ if "labels" in data.values.workload.metadata and \
+        #@    "app.kubernetes.io/part-of" in data.values.workload.metadata.labels:
+        app.kubernetes.io/part-of: #@ data.values.workload.metadata.labels["app.kubernetes.io/part-of"]
+        #@ end
+        carto.run/workload-name: #@ data.values.workload.metadata.name
+        app.kubernetes.io/component: run
+    spec:
+      template:
+        metadata:
+          annotations:
+            autoscaling.knative.dev/minScale: "1"
+        spec:
+          containers:
+            - name: workload
+              image: #@ data.values.image
+              securityContext:
+                runAsUser: 1000
+          imagePullSecrets:
+            - name: registry-credentials
+    #@ end
+    ---
     apiVersion: v1
     kind: ConfigMap
     metadata:
       name: #@ data.values.workload.metadata.name
     data:
-      #@yaml/text-templated-strings
-      manifest: |
-        apiVersion: serving.knative.dev/v1
-        kind: Service
-        metadata:
-          name: (@= data.values.workload.metadata.name @)
-          labels:
-            (@- if hasattr(data.values.workload.metadata, "labels"): @)
-            (@- if hasattr(data.values.workload.metadata.labels, "app.kubernetes.io/part-of"): @)
-            app.kubernetes.io/part-of: (@= data.values.workload.metadata.labels["app.kubernetes.io/part-of"] @)
-            (@ end -@)
-            (@ end -@)
-            carto.run/workload-name: (@= data.values.workload.metadata.name @)
-            app.kubernetes.io/component: run
-        spec:
-          template:
-            metadata:
-              annotations:
-                autoscaling.knative.dev/minScale: '1'
-            spec:
-              containers:
-                - name: workload
-                  image: (@= data.values.image @)
-                  securityContext:
-                    runAsUser: 1000
-              imagePullSecrets:
-                - name: registry-credentials
+      manifest: #@ yaml.encode(service())

--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -448,6 +448,7 @@ test_example_sc() {
         done
 
         log "testing '$test_name' FAILED :("
+        kubectl get configmaps -A -oyaml
         exit 1
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Cartographer!

Also check the [PR guidelines] if you haven't already!
-->

[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Changes proposed by this PR
<!--
Summarize your changes. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

This PR illustrates a recommendation to use YAML templating rather than text templating in the "Source to App Config In Git" example.

By:
- capturing the Knative Service object as a [YAML Fragment](https://carvel.dev/ytt/docs/v0.40.0/lang-ref-yaml-fragment), and
- [string-encoding that YAML](https://carvel.dev/ytt/docs/v0.40.0/lang-ref-ytt/#yaml) into the ConfigMap `manifest` entry
the end-user can avoid challenges related to text templating (e.g. string escaping, indentation).

Whenever a YAML structure is being built, the Carvel team recommends using this technique.

Also (minor): remove redundant `load()` call in `serviceaccount.yaml`: the scope of identifiers set from a `load()` is the entire file, not just the document.

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [ ] ~Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`~
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above 
- [x] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
