### PR TITLE
Remove owner prefix from options

### DIFF
--- a/pkg/apis/v1alpha1/cluster_delivery_test.go
+++ b/pkg/apis/v1alpha1/cluster_delivery_test.go
@@ -206,7 +206,7 @@ var _ = Describe("Delivery Validation", func() {
 										Selector: v1alpha1.Selector{
 											MatchFields: []v1alpha1.FieldSelectorRequirement{
 												{
-													Key:      "workload.spec.source.git.url",
+													Key:      "spec.source.git.url",
 													Operator: v1alpha1.FieldSelectorOpExists,
 												},
 											},
@@ -217,7 +217,7 @@ var _ = Describe("Delivery Validation", func() {
 										Selector: v1alpha1.Selector{
 											MatchFields: []v1alpha1.FieldSelectorRequirement{
 												{
-													Key:      "workload.spec.source.git.url",
+													Key:      "spec.source.git.url",
 													Operator: v1alpha1.FieldSelectorOpDoesNotExist,
 												},
 											},
@@ -422,18 +422,18 @@ var _ = Describe("Delivery Validation", func() {
 
 		Context("option points to key that doesn't exist in spec", func() {
 			BeforeEach(func() {
-				delivery.Spec.Resources[0].TemplateRef.Options[0].Selector.MatchFields[0].Key = "workload.spec.does.not.exist"
+				delivery.Spec.Resources[0].TemplateRef.Options[0].Selector.MatchFields[0].Key = "spec.does.not.exist"
 			})
 
 			It("on create, it rejects the Resource", func() {
 				Expect(delivery.ValidateCreate()).To(MatchError(
-					"error validating clusterdelivery [responsible-ops---default-params]: error validating resource [source-provider]: error validating option [source-1]: requirement key [workload.spec.does.not.exist] is not a valid workload path",
+					"error validating clusterdelivery [responsible-ops---default-params]: error validating resource [source-provider]: error validating option [source-1]: requirement key [spec.does.not.exist] is not a valid path",
 				))
 			})
 
 			It("on update, it rejects the Resource", func() {
 				Expect(delivery.ValidateUpdate(oldDelivery)).To(MatchError(
-					"error validating clusterdelivery [responsible-ops---default-params]: error validating resource [source-provider]: error validating option [source-1]: requirement key [workload.spec.does.not.exist] is not a valid workload path",
+					"error validating clusterdelivery [responsible-ops---default-params]: error validating resource [source-provider]: error validating option [source-1]: requirement key [spec.does.not.exist] is not a valid path",
 				))
 			})
 
@@ -444,7 +444,7 @@ var _ = Describe("Delivery Validation", func() {
 
 		Context("option points to key that is a valid prefix into an array", func() {
 			BeforeEach(func() {
-				delivery.Spec.Resources[0].TemplateRef.Options[0].Selector.MatchFields[0].Key = `workload.spec.env[?(@.name=="some-name")].value`
+				delivery.Spec.Resources[0].TemplateRef.Options[0].Selector.MatchFields[0].Key = `spec.params[?(@.name=="some-name")].value`
 			})
 
 			It("on create, it does not reject the Resource", func() {

--- a/pkg/apis/v1alpha1/cluster_delivery_validations.go
+++ b/pkg/apis/v1alpha1/cluster_delivery_validations.go
@@ -118,7 +118,7 @@ func validateDeliveryTemplateRef(ref DeliveryTemplateReference) error {
 		return fmt.Errorf("exactly one of templateRef.Name or templateRef.Options must be specified, found neither")
 	}
 
-	if err := validateResourceOptions(ref.Options); err != nil {
+	if err := validateResourceOptions(ref.Options, ValidDeliverablePaths, ValidDeliverablePrefixes); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/apis/v1alpha1/cluster_supply_chain_test.go
+++ b/pkg/apis/v1alpha1/cluster_supply_chain_test.go
@@ -462,7 +462,7 @@ var _ = Describe("ClusterSupplyChain", func() {
 											Selector: v1alpha1.Selector{
 												MatchFields: []v1alpha1.FieldSelectorRequirement{
 													{
-														Key:      "workload.spec.source.git.url",
+														Key:      "spec.source.git.url",
 														Operator: v1alpha1.FieldSelectorOpExists,
 													},
 												},
@@ -473,7 +473,7 @@ var _ = Describe("ClusterSupplyChain", func() {
 											Selector: v1alpha1.Selector{
 												MatchFields: []v1alpha1.FieldSelectorRequirement{
 													{
-														Key:      "workload.spec.source.git.url",
+														Key:      "spec.source.git.url",
 														Operator: v1alpha1.FieldSelectorOpDoesNotExist,
 													},
 												},
@@ -678,18 +678,18 @@ var _ = Describe("ClusterSupplyChain", func() {
 
 			Context("option points to key that doesn't exist in spec", func() {
 				BeforeEach(func() {
-					supplyChain.Spec.Resources[0].TemplateRef.Options[0].Selector.MatchFields[0].Key = "workload.spec.does.not.exist"
+					supplyChain.Spec.Resources[0].TemplateRef.Options[0].Selector.MatchFields[0].Key = "spec.does.not.exist"
 				})
 
 				It("on create, it rejects the Resource", func() {
 					Expect(supplyChain.ValidateCreate()).To(MatchError(
-						"error validating clustersupplychain [responsible-ops---default-params]: error validating resource [source-provider]: error validating option [source-1]: requirement key [workload.spec.does.not.exist] is not a valid workload path",
+						"error validating clustersupplychain [responsible-ops---default-params]: error validating resource [source-provider]: error validating option [source-1]: requirement key [spec.does.not.exist] is not a valid path",
 					))
 				})
 
 				It("on update, it rejects the Resource", func() {
 					Expect(supplyChain.ValidateUpdate(oldSupplyChain)).To(MatchError(
-						"error validating clustersupplychain [responsible-ops---default-params]: error validating resource [source-provider]: error validating option [source-1]: requirement key [workload.spec.does.not.exist] is not a valid workload path",
+						"error validating clustersupplychain [responsible-ops---default-params]: error validating resource [source-provider]: error validating option [source-1]: requirement key [spec.does.not.exist] is not a valid path",
 					))
 				})
 
@@ -700,7 +700,7 @@ var _ = Describe("ClusterSupplyChain", func() {
 
 			Context("option points to key that is a valid prefix into an array", func() {
 				BeforeEach(func() {
-					supplyChain.Spec.Resources[0].TemplateRef.Options[0].Selector.MatchFields[0].Key = `workload.spec.env[?(@.name=="some-name")].value`
+					supplyChain.Spec.Resources[0].TemplateRef.Options[0].Selector.MatchFields[0].Key = `spec.env[?(@.name=="some-name")].value`
 				})
 
 				It("on create, it does not reject the Resource", func() {

--- a/pkg/apis/v1alpha1/common_validations.go
+++ b/pkg/apis/v1alpha1/common_validations.go
@@ -1,0 +1,79 @@
+// Copyright 2021 VMware
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+func validateResourceOptions(options []TemplateOption, validPaths map[string]bool, validPrefixes []string) error {
+	for _, option := range options {
+		if err := validateFieldSelectorRequirements(option.Selector.MatchFields, validPaths, validPrefixes); err != nil {
+			return fmt.Errorf("error validating option [%s]: %w", option.Name, err)
+		}
+	}
+
+	for _, option1 := range options {
+		for _, option2 := range options {
+			if option1.Name != option2.Name && reflect.DeepEqual(option1.Selector, option2.Selector) {
+				return fmt.Errorf(
+					"duplicate selector found in options [%s, %s]",
+					option1.Name,
+					option2.Name,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateFieldSelectorRequirements(reqs []FieldSelectorRequirement, validPaths map[string]bool, validPrefixes []string) error {
+	for _, req := range reqs {
+		switch req.Operator {
+		case FieldSelectorOpExists, FieldSelectorOpDoesNotExist:
+			if len(req.Values) != 0 {
+				return fmt.Errorf("cannot specify values with operator [%s]", req.Operator)
+			}
+		case FieldSelectorOpIn, FieldSelectorOpNotIn:
+			if len(req.Values) == 0 {
+				return fmt.Errorf("must specify values with operator [%s]", req.Operator)
+			}
+		default:
+			return fmt.Errorf("operator [%s] is invalid", req.Operator)
+		}
+
+		if !validPath(req.Key, validPaths, validPrefixes) {
+			return fmt.Errorf("requirement key [%s] is not a valid path", req.Key)
+		}
+	}
+	return nil
+}
+
+func validPath(path string, validPaths map[string]bool, validPrefixes []string) bool {
+	if validPaths[path] {
+		return true
+	}
+
+	for _, prefix := range validPrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/apis/v1alpha1/deliverable.go
+++ b/pkg/apis/v1alpha1/deliverable.go
@@ -43,21 +43,21 @@ const (
 )
 
 var ValidDeliverablePaths = map[string]bool{
-	"deliverable.spec.source":                true,
-	"deliverable.spec.source.git":            true,
-	"deliverable.spec.source.git.url":        true,
-	"deliverable.spec.source.git.ref":        true,
-	"deliverable.spec.source.git.ref.branch": true,
-	"deliverable.spec.source.git.ref.tag":    true,
-	"deliverable.spec.source.git.ref.commit": true,
-	"deliverable.spec.source.image":          true,
-	"deliverable.spec.source.subPath":        true,
-	"deliverable.spec.serviceAccountName":    true,
+	"spec.source":                true,
+	"spec.source.git":            true,
+	"spec.source.git.url":        true,
+	"spec.source.git.ref":        true,
+	"spec.source.git.ref.branch": true,
+	"spec.source.git.ref.tag":    true,
+	"spec.source.git.ref.commit": true,
+	"spec.source.image":          true,
+	"spec.source.subPath":        true,
+	"spec.serviceAccountName":    true,
 }
 
 var ValidDeliverablePrefixes = []string{
-	"deliverable.spec.params",
-	"deliverable.metadata",
+	"spec.params",
+	"metadata",
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/apis/v1alpha1/workload.go
+++ b/pkg/apis/v1alpha1/workload.go
@@ -19,8 +19,6 @@
 package v1alpha1
 
 import (
-	"strings"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -44,28 +42,28 @@ const (
 
 // ValidWorkloadPaths Note: this needs to be updated anytime the spec changes
 var ValidWorkloadPaths = map[string]bool{
-	"workload.spec.source":                true,
-	"workload.spec.source.git":            true,
-	"workload.spec.source.git.url":        true,
-	"workload.spec.source.git.ref":        true,
-	"workload.spec.source.git.ref.branch": true,
-	"workload.spec.source.git.ref.tag":    true,
-	"workload.spec.source.git.ref.commit": true,
-	"workload.spec.source.image":          true,
-	"workload.spec.source.subPath":        true,
-	"workload.spec.build":                 true,
-	"workload.spec.image":                 true,
-	"workload.spec.serviceAccountName":    true,
+	"spec.source":                true,
+	"spec.source.git":            true,
+	"spec.source.git.url":        true,
+	"spec.source.git.ref":        true,
+	"spec.source.git.ref.branch": true,
+	"spec.source.git.ref.tag":    true,
+	"spec.source.git.ref.commit": true,
+	"spec.source.image":          true,
+	"spec.source.subPath":        true,
+	"spec.build":                 true,
+	"spec.image":                 true,
+	"spec.serviceAccountName":    true,
 }
 
 // ValidWorkloadPrefixes Note: this needs to be updated anytime the spec changes
 var ValidWorkloadPrefixes = []string{
-	"workload.spec.params",
-	"workload.spec.build.env",
-	"workload.spec.env",
-	"workload.spec.resources",
-	"workload.spec.serviceClaims",
-	"workload.metadata",
+	"spec.params",
+	"spec.build.env",
+	"spec.env",
+	"spec.resources",
+	"spec.serviceClaims",
+	"metadata",
 }
 
 // +kubebuilder:object:root=true
@@ -168,20 +166,6 @@ type WorkloadList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Workload `json:"items"`
-}
-
-func validWorkloadPath(path string) bool {
-	if ValidWorkloadPaths[path] {
-		return true
-	}
-
-	for _, prefix := range ValidWorkloadPrefixes {
-		if strings.HasPrefix(path, prefix) {
-			return true
-		}
-	}
-
-	return false
 }
 
 func init() {

--- a/pkg/realizer/deliverable/component.go
+++ b/pkg/realizer/deliverable/component.go
@@ -169,7 +169,8 @@ func (r *resourceRealizer) findMatchingTemplateName(resource *v1alpha1.DeliveryR
 		matchedAllFields := true
 		for _, field := range option.Selector.MatchFields {
 			dlContext := map[string]interface{}{
-				"deliverable": r.deliverable,
+				"spec":     r.deliverable.Spec,
+				"metadata": r.deliverable.ObjectMeta,
 			}
 			matched, err := selector.Matches(field, dlContext)
 			if err != nil {

--- a/pkg/realizer/workload/component.go
+++ b/pkg/realizer/workload/component.go
@@ -174,7 +174,8 @@ func (r *resourceRealizer) findMatchingTemplateName(resource *v1alpha1.SupplyCha
 		matchedAllFields := true
 		for _, field := range option.Selector.MatchFields {
 			wkContext := map[string]interface{}{
-				"workload": r.workload,
+				"spec":     r.workload.Spec,
+				"metadata": r.workload.ObjectMeta,
 			}
 			matched, err := selector.Matches(field, wkContext)
 			if err != nil {

--- a/pkg/realizer/workload/component_test.go
+++ b/pkg/realizer/workload/component_test.go
@@ -428,7 +428,7 @@ var _ = Describe("Resource", func() {
 								Selector: v1alpha1.Selector{
 									MatchFields: []v1alpha1.FieldSelectorRequirement{
 										{
-											Key:      "workload.spec.source.image",
+											Key:      "spec.source.image",
 											Operator: "Exists",
 										},
 									},
@@ -439,7 +439,7 @@ var _ = Describe("Resource", func() {
 								Selector: v1alpha1.Selector{
 									MatchFields: []v1alpha1.FieldSelectorRequirement{
 										{
-											Key:      "workload.spec.source.git.url",
+											Key:      "spec.source.git.url",
 											Operator: "Exists",
 										},
 									},
@@ -502,7 +502,7 @@ var _ = Describe("Resource", func() {
 
 			When("more than one option matches", func() {
 				It("returns a TemplateOptionsMatchError", func() {
-					resource.TemplateRef.Options[0].Selector.MatchFields[0].Key = "workload.spec.source.git.ref.branch"
+					resource.TemplateRef.Options[0].Selector.MatchFields[0].Key = "spec.source.git.ref.branch"
 
 					template, _, _, err := r.Do(ctx, &resource, supplyChainName, outputs)
 					Expect(template).To(BeNil())
@@ -515,8 +515,8 @@ var _ = Describe("Resource", func() {
 
 			When("zero options match", func() {
 				It("returns a TemplateOptionsMatchError", func() {
-					resource.TemplateRef.Options[0].Selector.MatchFields[0].Key = "workload.spec.source.image"
-					resource.TemplateRef.Options[1].Selector.MatchFields[0].Key = "workload.spec.source.subPath"
+					resource.TemplateRef.Options[0].Selector.MatchFields[0].Key = "spec.source.image"
+					resource.TemplateRef.Options[1].Selector.MatchFields[0].Key = "spec.source.subPath"
 
 					template, _, _, err := r.Do(ctx, &resource, supplyChainName, outputs)
 
@@ -529,21 +529,21 @@ var _ = Describe("Resource", func() {
 
 			When("key does not exist in the spec", func() {
 				It("returns a ResolveTemplateOptionError", func() {
-					resource.TemplateRef.Options[0].Selector.MatchFields[0].Key = `workload.spec.env[?(@.name=="some-name")].bad`
+					resource.TemplateRef.Options[0].Selector.MatchFields[0].Key = `spec.env[?(@.name=="some-name")].bad`
 
 					template, _, _, err := r.Do(ctx, &resource, supplyChainName, outputs)
 
 					Expect(template).To(BeNil())
 
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring(`key [workload.spec.env[?(@.name=="some-name")].bad] is invalid in template option [template-not-chosen] for resource [resource-1] in supply chain [supply-chain-name]: evaluate: failed to find results: bad is not found`))
+					Expect(err.Error()).To(ContainSubstring(`key [spec.env[?(@.name=="some-name")].bad] is invalid in template option [template-not-chosen] for resource [resource-1] in supply chain [supply-chain-name]: evaluate: failed to find results: bad is not found`))
 				})
 			})
 
 			When("one option matches with multiple fields", func() {
 				It("finds the correct template", func() {
 					resource.TemplateRef.Options[0].Selector.MatchFields = append(resource.TemplateRef.Options[0].Selector.MatchFields, v1alpha1.FieldSelectorRequirement{
-						Key:      "workload.spec.source.git.ref.branch",
+						Key:      "spec.source.git.ref.branch",
 						Operator: "Exists",
 					})
 

--- a/tests/kuttl/delivery/options-with-metadata/00-service-account.yaml
+++ b/tests/kuttl/delivery/options-with-metadata/00-service-account.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-service-account
+secrets:
+  - name: my-service-account-secret
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-service-account-secret
+  annotations:
+    kubernetes.io/service-account.name: my-service-account
+data:
+  token: "ZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNklubFNWM1YxVDNSRldESnZVRE4wTUd0R1EzQmlVVlJOVWtkMFNGb3RYMGh2VUhKYU1FRnVOR0Y0WlRBaWZRLmV5SnBjM01pT2lKcmRXSmxjbTVsZEdWekwzTmxjblpwWTJWaFkyTnZkVzUwSWl3aWEzVmlaWEp1WlhSbGN5NXBieTl6WlhKMmFXTmxZV05qYjNWdWRDOXVZVzFsYzNCaFkyVWlPaUprWldaaGRXeDBJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpXTnlaWFF1Ym1GdFpTSTZJbTE1TFhOaExYUnZhMlZ1TFd4dVkzRndJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpYSjJhV05sTFdGalkyOTFiblF1Ym1GdFpTSTZJbTE1TFhOaElpd2lhM1ZpWlhKdVpYUmxjeTVwYnk5elpYSjJhV05sWVdOamIzVnVkQzl6WlhKMmFXTmxMV0ZqWTI5MWJuUXVkV2xrSWpvaU9HSXhNV1V3WldNdFlURTVOeTAwWVdNeUxXRmpORFF0T0RjelpHSmpOVE13TkdKbElpd2ljM1ZpSWpvaWMzbHpkR1Z0T25ObGNuWnBZMlZoWTJOdmRXNTBPbVJsWm1GMWJIUTZiWGt0YzJFaWZRLmplMzRsZ3hpTUtnd0QxUGFhY19UMUZNWHdXWENCZmhjcVhQMEE2VUV2T0F6ek9xWGhpUUdGN2poY3RSeFhmUVFJVEs0Q2tkVmZ0YW5SUjNPRUROTUxVMVBXNXVsV3htVTZTYkMzdmZKT3ozLVJPX3BOVkNmVW8tZURpblN1Wm53bjNzMjNjZU9KM3IzYk04cnBrMHZZZFgyRVlQRGItMnd4cjIzZ1RxUjVxZU5ULW11cS1qYktXVE8wYnRYVl9wVHNjTnFXUkZIVzJBVTVHYVBpbmNWVXg1bXExLXN0SFdOOGtjTG96OF96S2RnUnJGYV92clFjb3NWZzZCRW5MSEt2NW1fVEhaR3AybU8wYmtIV3J1Q2xEUDdLc0tMOFVaZWxvTDN4Y3dQa000VlBBb2V0bDl5MzlvUi1KbWh3RUlIcS1hX3BzaVh5WE9EQU44STcybEZpUSU="
+type: kubernetes.io/service-account-token

--- a/tests/kuttl/delivery/options-with-metadata/00-templates.yaml
+++ b/tests/kuttl/delivery/options-with-metadata/00-templates.yaml
@@ -1,0 +1,46 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: carto.run/v1alpha1
+kind: ClusterSourceTemplate
+metadata:
+  name: git-template---options-delivery-with-metadata
+spec:
+  urlPath: .spec.value
+  revisionPath: .metadata.name
+  template:
+    apiVersion: test.run/v1alpha1
+    kind: Test
+    metadata:
+      name: test-git-template-options-with-metadata
+    spec:
+      value:
+        foo: fizz
+
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterSourceTemplate
+metadata:
+  name: imgpkg-bundle-template---options-delivery-with-metadata
+spec:
+  urlPath: .spec.value
+  revisionPath: .metadata.name
+  template:
+    apiVersion: test.run/v1alpha1
+    kind: Test
+    metadata:
+      name: test-imgpkg-bundle-template-options-with-metadata
+    spec:
+      value:
+        bar: bazz

--- a/tests/kuttl/delivery/options-with-metadata/01-delivery.yaml
+++ b/tests/kuttl/delivery/options-with-metadata/01-delivery.yaml
@@ -15,23 +15,21 @@
 apiVersion: carto.run/v1alpha1
 kind: ClusterDelivery
 metadata:
-  name: responsible-ops---options-with-values-delivery
+  name: responsible-ops---options-delivery-with-metadata
 spec:
   selector:
-    integration-test: "options-with-values-delivery"
+    integration-test: "options-delivery-with-metadata"
   resources:
     - name: source-provider
       templateRef:
         kind: ClusterSourceTemplate
         options:
-        - name: git-template---options-with-values-delivery
+        - name: git-template---options-delivery-with-metadata
           selector:
             matchFields:
-              - key: spec.source.git.url
-                operator: NotIn
-                values:
-                  -  "https://example.com"
-        - name: imgpkg-bundle-template---options-with-values-delivery
+              - key: metadata.labels.has-tests
+                operator: Exists
+        - name: imgpkg-bundle-template---options-delivery-with-metadata
           selector:
             matchFields:
               - key: spec.source.image

--- a/tests/kuttl/delivery/options-with-metadata/02-assert.yaml
+++ b/tests/kuttl/delivery/options-with-metadata/02-assert.yaml
@@ -12,25 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: carto.run/v1alpha1
-kind: ClusterSupplyChain
+apiVersion: test.run/v1alpha1
+kind: Test
 metadata:
-  name: responsible-ops---options
+  name: test-git-template-options-with-metadata
 spec:
-  selector:
-    integration-test: "options"
-  resources:
-    - name: source-provider
-      templateRef:
-        kind: ClusterSourceTemplate
-        options:
-        - name: git-template---options
-          selector:
-            matchFields:
-              - key: spec.source.git
-                operator: Exists
-        - name: imgpkg-bundle-template---options
-          selector:
-            matchFields:
-              - key: spec.source.image
-                operator: Exists
+  value:
+    foo: fizz
+
+---
+apiVersion: carto.run/v1alpha1
+kind: Deliverable
+metadata:
+  name: petclinic
+status:
+  conditions:
+    - type: DeliveryReady
+      status: "True"
+      reason: Ready
+    - type: ResourcesSubmitted
+      status: "True"
+      reason: ResourceSubmissionComplete
+    - type: Ready
+      status: "True"
+      reason: Ready
+  deliveryRef:
+    name: responsible-ops---options-delivery-with-metadata
+    kind: ClusterDelivery

--- a/tests/kuttl/delivery/options-with-metadata/02-deliverable.yaml
+++ b/tests/kuttl/delivery/options-with-metadata/02-deliverable.yaml
@@ -13,24 +13,22 @@
 # limitations under the License.
 
 apiVersion: carto.run/v1alpha1
-kind: ClusterSupplyChain
+kind: Deliverable
 metadata:
-  name: responsible-ops---options
+  name: petclinic
+  labels:
+    integration-test: "options-delivery-with-metadata"
+    has-tests: "true"
 spec:
-  selector:
-    integration-test: "options"
-  resources:
-    - name: source-provider
-      templateRef:
-        kind: ClusterSourceTemplate
-        options:
-        - name: git-template---options
-          selector:
-            matchFields:
-              - key: spec.source.git
-                operator: Exists
-        - name: imgpkg-bundle-template---options
-          selector:
-            matchFields:
-              - key: spec.source.image
-                operator: Exists
+  serviceAccountName: my-service-account
+  params:
+    - name: waciuma-com/quality
+      value: beta
+    - name: waciuma-com/java-version
+      value: 11
+
+  source:
+    git:
+      url: https://github.com/spring-projects/spring-petclinic.git
+      ref:
+        branch: main

--- a/tests/kuttl/delivery/options/01-delivery.yaml
+++ b/tests/kuttl/delivery/options/01-delivery.yaml
@@ -27,10 +27,10 @@ spec:
         - name: git-template---options-delivery
           selector:
             matchFields:
-              - key: deliverable.spec.source.git
+              - key: spec.source.git
                 operator: Exists
         - name: imgpkg-bundle-template---options-delivery
           selector:
             matchFields:
-              - key: deliverable.spec.source.image
+              - key: spec.source.image
                 operator: Exists

--- a/tests/kuttl/supplychain/options-with-metadata/00-service-account.yaml
+++ b/tests/kuttl/supplychain/options-with-metadata/00-service-account.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-service-account
+secrets:
+  - name: my-service-account-secret
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-service-account-secret
+  annotations:
+    kubernetes.io/service-account.name: my-service-account
+data:
+  token: "ZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNklubFNWM1YxVDNSRldESnZVRE4wTUd0R1EzQmlVVlJOVWtkMFNGb3RYMGh2VUhKYU1FRnVOR0Y0WlRBaWZRLmV5SnBjM01pT2lKcmRXSmxjbTVsZEdWekwzTmxjblpwWTJWaFkyTnZkVzUwSWl3aWEzVmlaWEp1WlhSbGN5NXBieTl6WlhKMmFXTmxZV05qYjNWdWRDOXVZVzFsYzNCaFkyVWlPaUprWldaaGRXeDBJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpXTnlaWFF1Ym1GdFpTSTZJbTE1TFhOaExYUnZhMlZ1TFd4dVkzRndJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpYSjJhV05sTFdGalkyOTFiblF1Ym1GdFpTSTZJbTE1TFhOaElpd2lhM1ZpWlhKdVpYUmxjeTVwYnk5elpYSjJhV05sWVdOamIzVnVkQzl6WlhKMmFXTmxMV0ZqWTI5MWJuUXVkV2xrSWpvaU9HSXhNV1V3WldNdFlURTVOeTAwWVdNeUxXRmpORFF0T0RjelpHSmpOVE13TkdKbElpd2ljM1ZpSWpvaWMzbHpkR1Z0T25ObGNuWnBZMlZoWTJOdmRXNTBPbVJsWm1GMWJIUTZiWGt0YzJFaWZRLmplMzRsZ3hpTUtnd0QxUGFhY19UMUZNWHdXWENCZmhjcVhQMEE2VUV2T0F6ek9xWGhpUUdGN2poY3RSeFhmUVFJVEs0Q2tkVmZ0YW5SUjNPRUROTUxVMVBXNXVsV3htVTZTYkMzdmZKT3ozLVJPX3BOVkNmVW8tZURpblN1Wm53bjNzMjNjZU9KM3IzYk04cnBrMHZZZFgyRVlQRGItMnd4cjIzZ1RxUjVxZU5ULW11cS1qYktXVE8wYnRYVl9wVHNjTnFXUkZIVzJBVTVHYVBpbmNWVXg1bXExLXN0SFdOOGtjTG96OF96S2RnUnJGYV92clFjb3NWZzZCRW5MSEt2NW1fVEhaR3AybU8wYmtIV3J1Q2xEUDdLc0tMOFVaZWxvTDN4Y3dQa000VlBBb2V0bDl5MzlvUi1KbWh3RUlIcS1hX3BzaVh5WE9EQU44STcybEZpUSU="
+type: kubernetes.io/service-account-token

--- a/tests/kuttl/supplychain/options-with-metadata/00-templates.yaml
+++ b/tests/kuttl/supplychain/options-with-metadata/00-templates.yaml
@@ -1,0 +1,46 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: carto.run/v1alpha1
+kind: ClusterSourceTemplate
+metadata:
+  name: git-template---options-with-metadata
+spec:
+  urlPath: .spec.value
+  revisionPath: .metadata.name
+  template:
+    apiVersion: test.run/v1alpha1
+    kind: Test
+    metadata:
+      name: test-git-template
+    spec:
+      value:
+        env: $(workload.spec.env)$
+
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterSourceTemplate
+metadata:
+  name: imgpkg-bundle-template---options-with-metadata
+spec:
+  urlPath: .spec.value
+  revisionPath: .metadata.name
+  template:
+    apiVersion: test.run/v1alpha1
+    kind: Test
+    metadata:
+      name: test-imgpkg-bundle-template
+    spec:
+      value:
+        env: $(workload.spec.build.env)$

--- a/tests/kuttl/supplychain/options-with-metadata/01-supply-chain.yaml
+++ b/tests/kuttl/supplychain/options-with-metadata/01-supply-chain.yaml
@@ -13,25 +13,23 @@
 # limitations under the License.
 
 apiVersion: carto.run/v1alpha1
-kind: ClusterDelivery
+kind: ClusterSupplyChain
 metadata:
-  name: responsible-ops---options-with-values-delivery
+  name: responsible-ops---options-with-metadata
 spec:
   selector:
-    integration-test: "options-with-values-delivery"
+    integration-test: "options-with-metadata"
   resources:
     - name: source-provider
       templateRef:
         kind: ClusterSourceTemplate
         options:
-        - name: git-template---options-with-values-delivery
+        - name: git-template---options-with-metadata
           selector:
             matchFields:
-              - key: spec.source.git.url
-                operator: NotIn
-                values:
-                  -  "https://example.com"
-        - name: imgpkg-bundle-template---options-with-values-delivery
+              - key: metadata.labels.has-tests
+                operator: Exists
+        - name: imgpkg-bundle-template---options-with-metadata
           selector:
             matchFields:
               - key: spec.source.image

--- a/tests/kuttl/supplychain/options-with-metadata/02-assert.yaml
+++ b/tests/kuttl/supplychain/options-with-metadata/02-assert.yaml
@@ -12,25 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: carto.run/v1alpha1
-kind: ClusterSupplyChain
+apiVersion: test.run/v1alpha1
+kind: Test
 metadata:
-  name: responsible-ops---options
+  name: test-git-template
 spec:
-  selector:
-    integration-test: "options"
-  resources:
-    - name: source-provider
-      templateRef:
-        kind: ClusterSourceTemplate
-        options:
-        - name: git-template---options
-          selector:
-            matchFields:
-              - key: spec.source.git
-                operator: Exists
-        - name: imgpkg-bundle-template---options
-          selector:
-            matchFields:
-              - key: spec.source.image
-                operator: Exists
+  value:
+    env:
+      - name: SPRING_PROFILES_ACTIVE
+        value: mysql
+
+---
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  name: petclinic
+status:
+  conditions:
+    - type: SupplyChainReady
+      status: "True"
+      reason: Ready
+    - type: ResourcesSubmitted
+      status: "True"
+      reason: ResourceSubmissionComplete
+    - type: Ready
+      status: "True"
+      reason: Ready
+  supplyChainRef:
+    name: responsible-ops---options-with-metadata
+    kind: ClusterSupplyChain

--- a/tests/kuttl/supplychain/options-with-metadata/02-workload.yaml
+++ b/tests/kuttl/supplychain/options-with-metadata/02-workload.yaml
@@ -1,0 +1,63 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  name: petclinic
+  labels:
+    integration-test: "options-with-metadata"
+    has-tests: "true"
+spec:
+  serviceAccountName: my-service-account
+  params:
+    - name: waciuma-com/quality
+      value: beta
+    - name: waciuma-com/java-version
+      value: 11
+
+  source:
+    git:
+      url: https://github.com/spring-projects/spring-petclinic.git
+      ref:
+        branch: main
+
+  serviceClaims:
+    - name: broker
+      ref:
+        apiVersion: services.tanzu.vmware.com/v1alpha1
+        kind: RabbitMQ
+        name: my-broker
+    - name: database
+      ref:
+        apiVersion: services.tanzu.vmware.com/v1alpha1
+        kind: MySQL
+        name: my-database
+
+  env:
+    - name: SPRING_PROFILES_ACTIVE
+      value: mysql
+
+  build:
+    env:
+      - name: SOME_BUILD_ENV
+        value: foo
+
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "250m"
+    limits:
+      memory: "2Gi"
+      cpu: "500m"

--- a/tests/kuttl/supplychain/options-with-values/01-supply-chain.yaml
+++ b/tests/kuttl/supplychain/options-with-values/01-supply-chain.yaml
@@ -27,12 +27,12 @@ spec:
         - name: git-template---options-with-values
           selector:
             matchFields:
-              - key: workload.spec.source.git.url
+              - key: spec.source.git.url
                 operator: NotIn
                 values:
                   - "https://example.com"
         - name: imgpkg-bundle-template---options-with-values
           selector:
             matchFields:
-              - key: workload.spec.source.image
+              - key: spec.source.image
                 operator: Exists


### PR DESCRIPTION
Co-authored-by: Emily Johnson <emjohnson@vmware.com>

<!--
Thanks for submitting a pull request to Cartographer!

Also check the [PR guidelines] if you haven't already!
-->

[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Changes proposed by this PR

<!--
Add the story that is resolved or updated
`closes`/`fixes` or `updates` are valid here 
-->
closes #668 

Removes workload/deliverable prefix from options

<!--
Summarize your changes. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->




<!--
Your PR title will be directly included in the release notes when it ships in
the next release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Add CreatorName field in Workload spec

Example notes:

* Operators can label stamped objects with the Workload's creator
* Creators can be contacted when interdepartmental issues arise 

If there are no additional notes necessary you may remove this entire section.
-->
[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [ ] Removed non-atomic or `wip` commits
- [ ] Filled in the [Release Note](#Release-Note) section above 
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
