### PR TITLE
hack: only publish `cartographer.yaml`

### DIFF
--- a/hack/publish-github-release.sh
+++ b/hack/publish-github-release.sh
@@ -35,10 +35,6 @@ submit_release_to_github() {
   gh release create $version \
     --draft \
     --notes-file $RELEASE_NOTES_FILE \
-    ./release/package/package.yaml \
-    ./release/package/package-install.yaml \
-    ./release/package/package-metadata.yaml \
-    ./release/bundle.tar \
     ./release/cartographer.yaml
 }
 


### PR DESCRIPTION


## Changes proposed by this PR

- remove inexistent files from github publishing script

with the removal of the production of `package*.yaml` objects from this
repository, when submitting the release to github, we shouldn't try to
upload those files as they don't exist anymore.

e.g., after release creation, `./release` now only has:

	release/
	├── CHANGELOG.md
	└── cartographer.yaml

with `CHANGELOG.md` being used as the body of the release, we should
then just upload `cartographer.yaml`.

note.: `package-*` objects can be found under
`vmware-tanzu/package-for-cartographer` (github repository).


## Release Note

None, internal change only.

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [ ] Removed non-atomic or `wip` commits
- [ ] Filled in the [Release Note](#Release-Note) section above 
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
