### PR TITLE
Adjust output of kubectl explain for deliverable service account

### DIFF
--- a/config/crd/bases/carto.run_deliverables.yaml
+++ b/config/crd/bases/carto.run_deliverables.yaml
@@ -85,9 +85,9 @@ spec:
               serviceAccountName:
                 description: "ServiceAccountName refers to the Service account with
                   permissions to create resources submitted by the supply chain. \n
-                  If not set, Cartographer will use serviceAccountName from supply
-                  chain. \n If that is also not set, Cartographer will use the default
-                  service account in the workload's namespace."
+                  If not set, Cartographer will use serviceAccountName from delivery.
+                  \n If that is also not set, Cartographer will use the default service
+                  account in the deliverable's namespace."
                 type: string
               source:
                 description: The location of the source code for the workload. Specify

--- a/pkg/apis/v1alpha1/deliverable.go
+++ b/pkg/apis/v1alpha1/deliverable.go
@@ -96,10 +96,10 @@ type DeliverableSpec struct {
 	// ServiceAccountName refers to the Service account with permissions to create resources
 	// submitted by the supply chain.
 	//
-	// If not set, Cartographer will use serviceAccountName from supply chain.
+	// If not set, Cartographer will use serviceAccountName from delivery.
 	//
 	// If that is also not set, Cartographer will use the default service account in the
-	// workload's namespace.
+	// deliverable's namespace.
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }

--- a/site/content/docs/development/crds/carto.run_deliverables.yaml
+++ b/site/content/docs/development/crds/carto.run_deliverables.yaml
@@ -18,9 +18,9 @@ spec:
   # ServiceAccountName refers to the Service account with
   # permissions to create resources submitted by the supply chain.
   # If not set, Cartographer will use serviceAccountName from
-  # supply chain. 
+  # delivery.
   # If that is also not set, Cartographer will use the default
-  # service account in the workload's namespace.
+  # service account in the deliverable's namespace.
   # +optional
   serviceAccountName: <string>
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Cartographer!

Also check the [PR guidelines] if you haven't already!
-->

[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Changes proposed by this PR

<!--
Add the story that is resolved or updated
`closes`/`fixes` or `updates` are valid here 
-->
closes #670 

<!--
Summarize your changes. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

Adjusted the information presented in kubectl explain for the deliverable's service account.

I was not sure if the following file should also be adjusted `site/content/docs/v0.2.0/crds/carto.run_deliverables.yaml`, I decided to not adjust it as it is referring to an `older` version of the documentation, but I can fix it there as well if necessary. 

## Release Note

Fix kubectl explain documentation for deliverable's service account.

<!--
Your PR title will be directly included in the release notes when it ships in
the next release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Add CreatorName field in Workload spec

Example notes:

* Operators can label stamped objects with the Workload's creator
* Creators can be contacted when interdepartmental issues arise 

If there are no additional notes necessary you may remove this entire section.
-->
[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [X] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [X] Removed non-atomic or `wip` commits
- [X] Filled in the [Release Note](#Release-Note) section above 
- [X] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
