### PR TITLE
Switch order of logger arguments to make dev flag work

### DIFF
--- a/cmd/cartographer/main.go
+++ b/cmd/cartographer/main.go
@@ -47,7 +47,7 @@ func main() {
 	cmd := cmd.Command{
 		Port:    port,
 		CertDir: certDir,
-		Logger:  zap.New(zap.UseDevMode(devMode), loggerOpt),
+		Logger:  zap.New(loggerOpt, zap.UseDevMode(devMode)),
 	}
 
 	if err = cmd.Execute(ctrl.SetupSignalHandler()); err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Cartographer!

Also check the [PR guidelines] if you haven't already!
-->

[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Changes proposed by this PR

<!--
Add the story that is resolved or updated
`closes`/`fixes` or `updates` are valid here 
-->
closes #598 

<!--
Summarize your changes. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

I simply switched around the order of the options provided. Maybe not the most sophisticated approach but during my testing it did the trick. 

## Release Note

- Fixed a bug with 'dev'-flag not being honored 
<!--
Your PR title will be directly included in the release notes when it ships in
the next release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Add CreatorName field in Workload spec

Example notes:

* Operators can label stamped objects with the Workload's creator
* Creators can be contacted when interdepartmental issues arise 

If there are no additional notes necessary you may remove this entire section.
-->
[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [X] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [X] Removed non-atomic or `wip` commits
- [X] Filled in the [Release Note](#Release-Note) section above 
- ~~[ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->~~
