### PR TITLE
Update docs for Selector

### DIFF
--- a/site/content/docs/development/crds/carto.run_clusterdeliveries.yaml
+++ b/site/content/docs/development/crds/carto.run_clusterdeliveries.yaml
@@ -97,7 +97,7 @@ spec:
         # +optional
         name: <string>
 
-        # Options is a list of template names and Selectors. The
+        # Options is a list of template names and Selector. The
         # templates must all be of type Kind. A template will be
         # selected if the deliverable matches the specified
         # selector. Only one template can be selected. Only one of
@@ -107,12 +107,40 @@ spec:
           - # Name of the template to apply
             name: <string>
 
-            # Selector is a field query over a workload or
-            # deliverable resource.
+            # Selector is a criteria to match against  a workload
+            # or deliverable resource.
             selector:
+
+              # matchExpressions is a list of label selector
+              # requirements. The requirements are ANDed.
+              # +optional
+              matchExpressions:
+                - # A label selector requirement is a selector
+                  # that contains values, a key, and an operator
+                  # that relates the key and values.
+                  # +optional
+
+                  # key is the label key that the selector applies
+                  # to.
+                  key: <string>
+
+                  # operator represents a key's relationship to a
+                  # set of values. Valid operators are In, NotIn,
+                  # Exists and DoesNotExist.
+                  operator: <string>
+
+                  # values is an array of string values. If the
+                  # operator is In or NotIn, the values array must
+                  # be non-empty. If the operator is Exists or
+                  # DoesNotExist, the values array must be empty.
+                  # This array is replaced during a strategic
+                  # merge patch.
+                  # +optional
+                  values: [ <string> ]
 
               # MatchFields is a list of field selector
               # requirements. The requirements are ANDed.
+              # +optional
               matchFields:
                 - # Key is the JSON path in the workload to match
                   # against. e.g. for workload:
@@ -130,7 +158,16 @@ spec:
                   # be non-empty. If the operator is Exists or
                   # DoesNotExist, the values array must be empty.
                   # +optional
-                  values:
+                  values: [ <string> ]
+
+              # matchLabels is a map of {key,value} pairs. A
+              # single {key,value} in the matchLabels map is
+              # equivalent to an element of matchExpressions,
+              # whose key field is "key", the operator is "In",
+              # and the values array contains only "value". The
+              # requirements are ANDed.
+              # +optional
+              matchLabels: {}
 
   # Specifies the label key-value pairs used to select owners See:
   # https://cartographer.sh/docs/v0.1.0/architecture/#selectors
@@ -161,8 +198,9 @@ spec:
       # be empty. This array is replaced during a strategic merge
       # patch.
       # +optional
-      values:
-- # Specifies the requirements used to select owners based on
+      values: [ <string> ]
+
+  # Specifies the requirements used to select owners based on
   # their fields See:
   # https://cartographer.sh/docs/v0.1.0/architecture/#selectors
   # +optional
@@ -182,8 +220,9 @@ spec:
       # operator is Exists or DoesNotExist, the values array must
       # be empty.
       # +optional
-      values:
-- # ServiceAccountName refers to the Service account with
+      values: [ <string> ]
+
+  # ServiceAccountName refers to the Service account with
   # permissions to create resources submitted by the supply chain.
   # If not set, Cartographer will use serviceAccountName from
   # supply chain. 

--- a/site/content/docs/development/crds/carto.run_clustersupplychains.yaml
+++ b/site/content/docs/development/crds/carto.run_clustersupplychains.yaml
@@ -102,7 +102,7 @@ spec:
         # +optional
         name: <string>
 
-        # Options is a list of template names and Selectors. The
+        # Options is a list of template names and Selector. The
         # templates must all be of type Kind. A template will be
         # selected if the workload matches the specified selector.
         # Only one template can be selected. Only one of Name and
@@ -113,12 +113,40 @@ spec:
           - # Name of the template to apply
             name: <string>
 
-            # Selector is a field query over a workload or
-            # deliverable resource.
+            # Selector is a criteria to match against  a workload
+            # or deliverable resource.
             selector:
+
+              # matchExpressions is a list of label selector
+              # requirements. The requirements are ANDed.
+              # +optional
+              matchExpressions:
+                - # A label selector requirement is a selector
+                  # that contains values, a key, and an operator
+                  # that relates the key and values.
+                  # +optional
+
+                  # key is the label key that the selector applies
+                  # to.
+                  key: <string>
+
+                  # operator represents a key's relationship to a
+                  # set of values. Valid operators are In, NotIn,
+                  # Exists and DoesNotExist.
+                  operator: <string>
+
+                  # values is an array of string values. If the
+                  # operator is In or NotIn, the values array must
+                  # be non-empty. If the operator is Exists or
+                  # DoesNotExist, the values array must be empty.
+                  # This array is replaced during a strategic
+                  # merge patch.
+                  # +optional
+                  values: [ <string> ]
 
               # MatchFields is a list of field selector
               # requirements. The requirements are ANDed.
+              # +optional
               matchFields:
                 - # Key is the JSON path in the workload to match
                   # against. e.g. for workload:
@@ -136,7 +164,16 @@ spec:
                   # be non-empty. If the operator is Exists or
                   # DoesNotExist, the values array must be empty.
                   # +optional
-                  values:
+                  values: [ <string> ]
+
+              # matchLabels is a map of {key,value} pairs. A
+              # single {key,value} in the matchLabels map is
+              # equivalent to an element of matchExpressions,
+              # whose key field is "key", the operator is "In",
+              # and the values array contains only "value". The
+              # requirements are ANDed.
+              # +optional
+              matchLabels: {}
 
   # Specifies the label key-value pairs used to select owners See:
   # https://cartographer.sh/docs/v0.1.0/architecture/#selectors
@@ -167,8 +204,9 @@ spec:
       # be empty. This array is replaced during a strategic merge
       # patch.
       # +optional
-      values:
-- # Specifies the requirements used to select owners based on
+      values: [ <string> ]
+
+  # Specifies the requirements used to select owners based on
   # their fields See:
   # https://cartographer.sh/docs/v0.1.0/architecture/#selectors
   # +optional
@@ -188,8 +226,9 @@ spec:
       # operator is Exists or DoesNotExist, the values array must
       # be empty.
       # +optional
-      values:
-- # ServiceAccountName refers to the Service account with
+      values: [ <string> ]
+
+  # ServiceAccountName refers to the Service account with
   # permissions to create resources submitted by the supply chain.
   # If not set, Cartographer will use serviceAccountName from
   # supply chain. 

--- a/site/hack/crd_lib/spec.rb
+++ b/site/hack/crd_lib/spec.rb
@@ -163,13 +163,18 @@ class Spec
     end
 
     class ArrayNode
-      attr_reader :name, :items, :description
+      attr_reader :name, :items, :description, :scalar_item_type
 
       def initialize(node_hash, name = "", required = false)
         @name = name
         @description = node_hash["description"]
         @required = required
-        @items = ItemsNode.new(node_hash.dig("items"))
+
+        if node_hash["items"]["type"] == "object"
+          @items = ItemsNode.new(node_hash.dig("items"))
+        else
+          @scalar_item_type = node_hash["items"]["type"]
+        end
       end
 
       def required?
@@ -178,8 +183,12 @@ class Spec
 
       def to_y(writer)
         writer.comment(description, !required?)
-        writer.puts "#{name}:"
-        writer.indent { @items.to_y(writer) }
+        if @items
+          writer.puts "#{name}:"
+          writer.indent { @items.to_y(writer) }
+        elsif @scalar_item_type
+          writer.puts "#{name}: [ <#{scalar_item_type}> ]"
+        end
       end
     end
 


### PR DESCRIPTION
Update architecture and CRD docs for selectors.

- small improvement to CRD docs generator to better represent arrays of scalars.

closes #669 #663 

## Release Note

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
