### PR TITLE
Fix RBAC errors in basic-delivery example

### DIFF
--- a/examples/basic-delivery/app-operator/deliverable.yaml
+++ b/examples/basic-delivery/app-operator/deliverable.yaml
@@ -21,6 +21,7 @@ metadata:
   labels:
     app.tanzu.vmware.com/workload-type: deliver
 spec:
+  serviceAccountName: #@ data.values.service_account_name
   source:
     git:
       url: #@ data.values.git_writer.repository

--- a/examples/basic-delivery/app-operator/delivery.yaml
+++ b/examples/basic-delivery/app-operator/delivery.yaml
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#@ load("@ytt:data", "data")
----
 apiVersion: carto.run/v1alpha1
 kind: ClusterDelivery
 metadata:
@@ -21,7 +19,7 @@ metadata:
 spec:
   selector:
     app.tanzu.vmware.com/workload-type: deliver
-    
+
   #
   #
   #   source-provider <--[src]--   deployer

--- a/examples/basic-delivery/app-operator/delivery.yaml
+++ b/examples/basic-delivery/app-operator/delivery.yaml
@@ -21,8 +21,6 @@ metadata:
 spec:
   selector:
     app.tanzu.vmware.com/workload-type: deliver
-  serviceAccountRef:
-    name: #@ data.values.service_account_name
     
   #
   #

--- a/examples/basic-delivery/app-operator/deploy-app.yaml
+++ b/examples/basic-delivery/app-operator/deploy-app.yaml
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#@ load("@ytt:data", "data")
----
 apiVersion: carto.run/v1alpha1
 kind: ClusterDeploymentTemplate
 metadata:

--- a/examples/basic-delivery/app-operator/deploy-app.yaml
+++ b/examples/basic-delivery/app-operator/deploy-app.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#@ load("@ytt:data", "data")
+---
 apiVersion: carto.run/v1alpha1
 kind: ClusterDeploymentTemplate
 metadata:
@@ -32,7 +34,7 @@ spec:
     metadata:
       name: $(deliverable.metadata.name)$
     spec:
-      serviceAccountName: default
+      serviceAccountName: #@ data.values.service_account_name
       fetch:
         - http:
             url: $(deployment.url)$

--- a/examples/basic-delivery/app-operator/deploy-app.yaml
+++ b/examples/basic-delivery/app-operator/deploy-app.yaml
@@ -34,7 +34,7 @@ spec:
     metadata:
       name: $(deliverable.metadata.name)$
     spec:
-      serviceAccountName: #@ data.values.service_account_name
+      serviceAccountName: $(deliverable.spec.serviceAccountName)$
       fetch:
         - http:
             url: $(deployment.url)$

--- a/examples/basic-delivery/app-operator/service-account.yaml
+++ b/examples/basic-delivery/app-operator/service-account.yaml
@@ -14,29 +14,37 @@
 
 #@ load("@ytt:data", "data")
 ---
-apiVersion: carto.run/v1alpha1
-kind: ClusterDelivery
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
-  name: deliver
-spec:
-  selector:
-    app.tanzu.vmware.com/workload-type: deliver
-  serviceAccountRef:
+  name: deliverable-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: deliverable-role
+subjects:
+  - kind: ServiceAccount
     name: #@ data.values.service_account_name
-    
-  #
-  #
-  #   source-provider <--[src]--   deployer
-  #     GitRepository               App
-  resources:
-    - name: source-provider
-      templateRef:
-        kind: ClusterSourceTemplate
-        name: gitops-source
 
-    - name: deployer
-      templateRef:
-        kind: ClusterDeploymentTemplate
-        name: app-deploy
-      deployment:
-        resource: source-provider
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: deliverable-role
+rules:
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+      - serving.knative.dev
+      - ""
+    resources:
+      - gitrepositories
+      - services
+      - configmaps
+    verbs:
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+      - get

--- a/examples/basic-delivery/values.yaml
+++ b/examples/basic-delivery/values.yaml
@@ -17,3 +17,4 @@
 git_writer:
   repository: github.com/example/example.git
   branch: main
+service_account_name: default


### PR DESCRIPTION
Resolves RBAC errors in `examples/basic-delivery`:
- Error 1: Failing to get FluxCD GitRepository resources
- Error 2: Failing to get ConfigMaps resource

## Changes proposed by this PR

- Add `serviceAccountRef.name: #@ data.values.service_account_name` in ClusterDelivery (fixes error 1)
- Add Role and RoleBinding with missing permissions for Delivery (following approach used for `examples/gitwriter-sc`) and updating App.kappctrl.k14s.io definition in ClusterDeploymentTemplate to use `serviceAccountName: #@ data.values.service_account_name`

Closes #674

## Release Note

Fix RBAC errors in basic-delivery example

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x ] Removed non-atomic or `wip` commits
- [x ] Filled in the [Release Note](#Release-Note) section above 
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
