### PR TITLE
github: point dependabot at `site`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,9 @@ updates:
     schedule:
       interval: daily
       time: "00:00"
+  - package-ecosystem: npm
+    labels: ["dependencies"]
+    directory: /site
+    schedule:
+      interval: daily
+      time: "00:00"


### PR DESCRIPTION
## Changes proposed by this PR

- point dependabot at `./site`

we've been getting some security notices about dependencies found under
`./site`, but given that we're not pointing dependabot, we've not been
getting the automatic bumps from it.


## Release Note

None - internal change only.

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [ ] Removed non-atomic or `wip` commits
- [ ] Filled in the [Release Note](#Release-Note) section above 
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
