### PR TITLE
config: add `app.kubernetes.io/component` label

### DIFF
--- a/hack/overlays/component-labels.yaml
+++ b/hack/overlays/component-labels.yaml
@@ -20,4 +20,4 @@ metadata:
   #@overlay/match missing_ok=True
   labels:
     #@overlay/match missing_ok=True
-    app.kubernetes.io/component: cartographer.carto.run
+    app.kubernetes.io/component: cartographer

--- a/hack/overlays/component-labels.yaml
+++ b/hack/overlays/component-labels.yaml
@@ -14,14 +14,7 @@
 
 #@ load("@ytt:overlay", "overlay")
 
-#@ def not_matcher(marg):
-#@   def matcher(*args, **kwargs):
-#@     return not marg(*args, **kwargs)
-#@   end
-#@   return matcher
-#@ end
-
-#@overlay/match by=not_matcher(overlay.subset({"kind":"Namespace"})),expects="1+"
+#@overlay/match by=overlay.not_op(overlay.subset({"kind":"Namespace"})),expects="1+"
 ---
 metadata:
   #@overlay/match missing_ok=True

--- a/hack/overlays/component-labels.yaml
+++ b/hack/overlays/component-labels.yaml
@@ -1,0 +1,30 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#@ load("@ytt:overlay", "overlay")
+
+#@ def not_matcher(marg):
+#@   def matcher(*args, **kwargs):
+#@     return not marg(*args, **kwargs)
+#@   end
+#@   return matcher
+#@ end
+
+#@overlay/match by=not_matcher(overlay.subset({"kind":"Namespace"})),expects="1+"
+---
+metadata:
+  #@overlay/match missing_ok=True
+  labels:
+    #@overlay/match missing_ok=True
+    app.kubernetes.io/component: cartographer.carto.run

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -74,6 +74,7 @@ generate_release() {
         mkdir -p ./release
         ytt --ignore-unknown-comments -f ./config \
                 -f ./hack/overlays/webhook-configuration.yaml \
+                -f ./hack/overlays/component-labels.yaml \
                 --data-value version=$RELEASE_VERSION |
                 KO_DOCKER_REPO=$REGISTRY ko resolve -B -f- > \
                         ./release/cartographer.yaml


### PR DESCRIPTION
## Changes proposed by this PR

- add an overlay used by the release process to add to all objects the `app.kubernetes.io/component` label to identify objects as being all part of cartographer

following the best practices when it comes to labelling objects (see
[1]), by making use of the recommended `app.kubernetes.io/component`,
we're able to clearly identify those objects that are part of
cartographer (useful for any tool that might want to do some form of
matching against anything cartographer-related, e.g., getting rid of all
of them based on matching on such label).

the approach I took here is to make use of ytt overlays in order to add
the label to all components _except_ the Namespace.

[1]: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/


## Release Note

- Add `app.kubernetes.io/component: cartographer.carto.run` label to all cartographer objects (except namespace).

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [ ] Removed non-atomic or `wip` commits
- [ ] Filled in the [Release Note](#Release-Note) section above 
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
