### PR TITLE
update sample repository

### DIFF
--- a/examples/basic-sc/README.md
+++ b/examples/basic-sc/README.md
@@ -300,7 +300,7 @@ metadata:
 spec:
   source:
     git:
-      url: https://github.com/kontinue/hello-world
+      url: https://github.com/carto-labs/hello-world
       revision: 3d42c19a618bb8fc13f72178b8b5e214a2f989c4
   ...
 ```
@@ -320,7 +320,7 @@ metadata:
   name: hello-world
 spec:
   source:
-    git: {url: https://github.com/kontinue/hello-world, revision: main}
+    git: {url: https://github.com/carto-labs/hello-world, revision: main}
     ...
 status:
 	latestImage: index.docker.io/projectcartographer/hello-world@sha256:27452d42b
@@ -340,7 +340,7 @@ metadata:
 spec:
   source:
     git:
-      url: https://github.com/kontinue/hello-world
+      url: https://github.com/carto-labs/hello-world
       revision: $(most_recent_commit)$
   ...
 ```
@@ -380,7 +380,7 @@ metadata:
   name: git-repository
 spec:
   interval: 1m
-  url: https://github.com/kontinue/hello-world
+  url: https://github.com/carto-labs/hello-world
   ref: {branch: main}
 ```
 
@@ -394,7 +394,7 @@ metadata:
   name: git-repository
 spec:
   interval: 1m
-  url: https://github.com/kontinue/hello-world
+  url: https://github.com/carto-labs/hello-world
   ref: {branch: main}
 status:
   artifact:
@@ -602,7 +602,7 @@ metadata:
 spec:
   source:
     git:
-      url: https://github.com/kontinue/hello-world
+      url: https://github.com/carto-labs/hello-world
       ref: {branch: main}
 ```
 

--- a/examples/basic-sc/developer/workload.yaml
+++ b/examples/basic-sc/developer/workload.yaml
@@ -24,7 +24,7 @@ spec:
   serviceAccountName: #@ data.values.service_account_name
   source:
     git:
-      url: https://github.com/kontinue/hello-world
+      url: https://github.com/carto-labs/hello-world
       ref:
         branch: main
   build:

--- a/examples/runnable-tekton/01-tests-pass/runnable.yml
+++ b/examples/runnable-tekton/01-tests-pass/runnable.yml
@@ -23,5 +23,5 @@ spec:
     name: tekton-taskrun
 
   inputs:
-    blob-url: https://github.com/kontinue/hello-world
+    blob-url: https://github.com/carto-labs/hello-world
     blob-revision: 19769456b6b229b3e78f2b90eced15a353eb4e7c

--- a/examples/runnable-tekton/README.md
+++ b/examples/runnable-tekton/README.md
@@ -88,7 +88,7 @@ status:
   observedGeneration: 1
   outputs:
     revision: 19769456b6b229b3e78f2b90eced15a353eb4e7c
-    url: https://github.com/kontinue/hello-world
+    url: https://github.com/carto-labs/hello-world
 ```
 
 Now let's update the Runnable with a different SHA, one where the tests fail:
@@ -124,7 +124,7 @@ kubectl logs Pod/test-zctzd-pod
 === RUN   TestDummy
 --- FAIL: TestDummy (0.00s)
 FAIL
-FAIL    github.com/kontinue/hello-world 0.009s
+FAIL    github.com/carto-labs/hello-world 0.009s
 FAIL
 ```
 
@@ -143,7 +143,7 @@ spec: ...
 status:
   outputs:
     revision: 19769456b6b229b3e78f2b90eced15a353eb4e7c  # <=== old sha
-    url: https://github.com/kontinue/hello-world
+    url: https://github.com/carto-labs/hello-world
 ```
 
 Now let's update Runnable with a commit where tests again pass:
@@ -185,7 +185,7 @@ spec: ...
 status:
   outputs:
     revision: 3d42c19a618bb8fc13f72178b8b5e214a2f989c4  # <=== new sha
-    url: https://github.com/kontinue/hello-world
+    url: https://github.com/carto-labs/hello-world
   ...
 ```
 
@@ -251,7 +251,7 @@ spec:
     name: test
   params:
   - name: blob-url
-    value: https://github.com/kontinue/hello-world
+    value: https://github.com/carto-labs/hello-world
   - name: blob-revision
     value: 3d42c19a618bb8fc13f72178b8b5e214a2f989c4
 ```
@@ -266,7 +266,7 @@ metadata:
 spec:
   params:
     - name: blob-url
-      value: https://github.com/kontinue/hello-world
+      value: https://github.com/carto-labs/hello-world
     - name: blob-revision
       value: 3d42c19a618bb8fc13f72178b8b5e214a2f989c4
   ...

--- a/examples/testing-sc/README.md
+++ b/examples/testing-sc/README.md
@@ -147,7 +147,7 @@ spec:
     name: go-builder
   source:
     git:
-      url: https://github.com/kontinue/hello-world
+      url: https://github.com/carto-labs/hello-world
       revision: main
 ```
 
@@ -171,7 +171,7 @@ metadata:
 spec:
   source:
     git:
-      url: https://github.com/kontinue/hello-world
+      url: https://github.com/carto-labs/hello-world
       revision: $(commit_that_passed_tests)$
   ...
 ```

--- a/examples/testing-sc/developer/workload.yaml
+++ b/examples/testing-sc/developer/workload.yaml
@@ -24,7 +24,7 @@ spec:
   serviceAccountName: #@ data.values.service_account_name
   source:
     git:
-      url: https://github.com/kontinue/hello-world
+      url: https://github.com/carto-labs/hello-world
       ref:
         branch: main
   build:

--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -450,7 +450,7 @@ setup_source_to_gitops() {
           --data-value registry.server="$REGISTRY" \
           --data-value workload_name="$test_name" \
           --data-value image_prefix="$REGISTRY/example-$test_name-" \
-          --data-value source_repo.url="https://github.com/kontinue/hello-world" \
+          --data-value source_repo.url="https://github.com/carto-labs/hello-world" \
           --data-value source_repo.branch="main" \
           --data-value git_repository="$GITOPS_REPO" \
           --data-value git_branch="$GITOPS_BRANCH" \

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -111,7 +111,7 @@ setup_source_repo() {
   pushd "$source_dir"
     git clone "http://localhost:$port/$SOURCE_REPO.git"
     pushd "$SOURCE_REPO"
-      git pull https://github.com/kontinue/hello-world.git
+      git pull https://github.com/carto-labs/hello-world.git
       if [[ $(git branch --show-current) != "$SOURCE_BRANCH" ]]; then
         git checkout -b $SOURCE_BRANCH
       fi


### PR DESCRIPTION
## Changes proposed by this PR

- replace `kontinue/hello-world` with [`carto-run/hello-world`](https://github.com/carto-run/hello-world)

previously, we used to point at the `kontinue/hello-world` repository as
the source of code to be used in tests as well as some docs but, with
that repository having gone away (replaced by `carto-run/hello-world`),
here I replace the former by the latter.


## Release Note

None - internal changes only.

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [ ] Removed non-atomic or `wip` commits
- [ ] Filled in the [Release Note](#Release-Note) section above 
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
