### PR TITLE
Revert work to avoid tests for *.md and rfcs

### DIFF
--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -16,14 +16,8 @@ name: upgrade test
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'rfc/**'
-      - '*.md'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'rfc/**'
-      - '*.md'
 
   schedule: # daily run
     - cron: '0 0 * * *'

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -16,14 +16,8 @@ name: validation
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'rfc/**'
-      - '*.md'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'rfc/**'
-      - '*.md'
 
   schedule: # daily run
     - cron: '0 0 * * *'


### PR DESCRIPTION
A problem arose that dependabot automation requires us to guard
merging on the build job. We don't have the time to properly address
this right now

Co-authored-by: Sam Coward <scoward@vmware.com>
