### PR TITLE
Don't use a third party repo

### DIFF
--- a/.github/actions/create-and-test-release/action.yaml
+++ b/.github/actions/create-and-test-release/action.yaml
@@ -36,6 +36,13 @@ runs:
         sudo apt update && sudo apt install -y curl tar
         ./hack/ci/install-binaries.sh ko tree grype
 
+
+    - name: prepare cluster
+      shell: bash
+      run: |
+        sudo ./hack/ci/trust-local-registry.sh
+        ./hack/setup.sh cluster
+
     - name: generate a cartographer release
       shell: bash
       env:
@@ -63,7 +70,7 @@ runs:
     - name: run e2e example
       shell: bash
       run: |
-        ./hack/setup.sh cluster pre-built-cartographer example-dependencies example
+        ./hack/setup.sh pre-built-cartographer example-dependencies example
 
     - name: scan image
       shell: bash

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -44,6 +44,3 @@ jobs:
         uses: ./.github/actions/create-and-test-release
         with:
           version: v0.0.0-dev
-          docker-registry: projectcartographer
-          docker-username: projectcartographer
-          docker-password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
- allows forks to use the hack.sh local registry
- forks should no longer fail
- means that release testing is less complete, unfortunately

Proof that it works: #867