### PR TITLE
812 owner healthy status

### DIFF
--- a/pkg/apis/v1alpha1/conditions.go
+++ b/pkg/apis/v1alpha1/conditions.go
@@ -26,6 +26,7 @@ package v1alpha1
 
 const (
 	OwnerReady               = "Ready"
+	ResourcesHealthy         = "ResourcesHealthy"
 	WorkloadSupplyChainReady = "SupplyChainReady"
 	DeliverableDeliveryReady = "DeliveryReady"
 	OwnerResourcesSubmitted  = "ResourcesSubmitted"
@@ -128,6 +129,7 @@ const (
 const (
 	NoResourceResourcesHealthyReason         = "NoResource"
 	OutputNotAvailableResourcesHealthyReason = "OutputNotAvailable"
+	NoStampedObjectHealthyReason             = "NoStampedObject"
 )
 
 // -- BLUEPRINT ConditionType - ResourcesHealthy False ConditionReasons

--- a/pkg/conditions/condition_utils.go
+++ b/pkg/conditions/condition_utils.go
@@ -1,0 +1,28 @@
+// Copyright 2021 VMware
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conditions
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+type ConditionList []metav1.Condition
+
+func (c ConditionList) ConditionWithType(conditionType string) *metav1.Condition {
+	for _, condition := range c {
+		if condition.Type == conditionType {
+			return &condition
+		}
+	}
+	return nil
+}

--- a/pkg/conditions/owner_conditions.go
+++ b/pkg/conditions/owner_conditions.go
@@ -44,6 +44,15 @@ func ResourcesSubmittedCondition(isOwner bool) metav1.Condition {
 	}
 }
 
+// -- Owner.Status.Conditions - ResourcesHealthy - True/False/Unknown
+
+func ResourcesHealthyCondition(status metav1.ConditionStatus) metav1.Condition {
+	return metav1.Condition{
+		Type:   v1alpha1.ResourcesHealthy,
+		Status: status,
+	}
+}
+
 // -- Owner.Status.Resource[x].Conditions - ResourceSubmitted &&
 // -- Owner.Status.Conditions - ResourcesSubmitted
 

--- a/pkg/conditions/resource_conditions.go
+++ b/pkg/conditions/resource_conditions.go
@@ -50,10 +50,19 @@ func SingleConditionMatchCondition(status metav1.ConditionStatus, conditionName 
 
 // -- Resource.Conditions - ResourcesHealthy - Unknown
 
+func NoStampedObjectResourcesHealthyCondition() metav1.Condition {
+	return metav1.Condition{
+		Type:   v1alpha1.ResourceHealthy,
+		Status: metav1.ConditionUnknown,
+		Reason: v1alpha1.NoStampedObjectHealthyReason,
+	}
+}
+
 func UnknownResourcesHealthyCondition() metav1.Condition {
 	return metav1.Condition{
 		Type:   v1alpha1.ResourceHealthy,
 		Status: metav1.ConditionUnknown,
+		Reason: "Unknokwn",
 	}
 }
 

--- a/pkg/controllers/deliverable_reconciler.go
+++ b/pkg/controllers/deliverable_reconciler.go
@@ -39,6 +39,7 @@ import (
 	"github.com/vmware-tanzu/cartographer/pkg/mapper"
 	"github.com/vmware-tanzu/cartographer/pkg/realizer"
 	realizerclient "github.com/vmware-tanzu/cartographer/pkg/realizer/client"
+	"github.com/vmware-tanzu/cartographer/pkg/realizer/healthcheck"
 	"github.com/vmware-tanzu/cartographer/pkg/realizer/statuses"
 	"github.com/vmware-tanzu/cartographer/pkg/repository"
 	"github.com/vmware-tanzu/cartographer/pkg/templates"
@@ -131,6 +132,8 @@ func (r *DeliverableReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	} else {
 		r.conditionManager.AddPositive(conditions.ResourcesSubmittedCondition(true))
 	}
+
+	r.conditionManager.AddPositive(healthcheck.OwnerHealthCondition(resourceStatuses.GetCurrent(), deliverable.Status.Conditions))
 
 	if err != nil {
 		log.V(logger.DEBUG).Info("failed to realize")

--- a/pkg/controllers/workload_reconciler.go
+++ b/pkg/controllers/workload_reconciler.go
@@ -39,6 +39,7 @@ import (
 	"github.com/vmware-tanzu/cartographer/pkg/mapper"
 	"github.com/vmware-tanzu/cartographer/pkg/realizer"
 	realizerclient "github.com/vmware-tanzu/cartographer/pkg/realizer/client"
+	"github.com/vmware-tanzu/cartographer/pkg/realizer/healthcheck"
 	"github.com/vmware-tanzu/cartographer/pkg/realizer/statuses"
 	"github.com/vmware-tanzu/cartographer/pkg/repository"
 	"github.com/vmware-tanzu/cartographer/pkg/templates"
@@ -135,6 +136,8 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	} else {
 		r.conditionManager.AddPositive(conditions.ResourcesSubmittedCondition(true))
 	}
+
+	r.conditionManager.AddPositive(healthcheck.OwnerHealthCondition(resourceStatuses.GetCurrent(), workload.Status.Conditions))
 
 	if err != nil {
 		log.V(logger.DEBUG).Info("failed to realize")

--- a/pkg/realizer/healthcheck/healthcheck_test.go
+++ b/pkg/realizer/healthcheck/healthcheck_test.go
@@ -41,8 +41,12 @@ var _ = Describe("DetermineHealthCondition", func() {
 		))
 	})
 
-	It("is always healthy for no rule on ClusterTemplates", func() {
+	It("is always healthy for no rule on ClusterTemplates if a stamped object exists", func() {
 		realizedResource := &v1alpha1.RealizedResource{
+			StampedRef: &corev1.ObjectReference{
+				Kind:       "Anything",
+				APIVersion: "of-any/kind",
+			},
 			TemplateRef: &corev1.ObjectReference{
 				Kind:       "ClusterTemplate",
 				APIVersion: "carto.run/v1alpha1",
@@ -54,6 +58,23 @@ var _ = Describe("DetermineHealthCondition", func() {
 				"Type":   Equal("Healthy"),
 				"Status": Equal(metav1.ConditionTrue),
 				"Reason": Equal(v1alpha1.AlwaysHealthyResourcesHealthyReason),
+			},
+		))
+	})
+
+	It("is always unknown for no rule on ClusterTemplates if no stamped object exists", func() {
+		realizedResource := &v1alpha1.RealizedResource{
+			TemplateRef: &corev1.ObjectReference{
+				Kind:       "ClusterTemplate",
+				APIVersion: "carto.run/v1alpha1",
+			},
+		}
+
+		Expect(healthcheck.DetermineHealthCondition(nil, realizedResource, nil)).To(MatchFields(IgnoreExtras,
+			Fields{
+				"Type":   Equal("Healthy"),
+				"Status": Equal(metav1.ConditionUnknown),
+				"Reason": Equal(v1alpha1.NoStampedObjectHealthyReason),
 			},
 		))
 	})

--- a/pkg/realizer/realizer.go
+++ b/pkg/realizer/realizer.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/vmware-tanzu/cartographer/pkg/apis/v1alpha1"
+	"github.com/vmware-tanzu/cartographer/pkg/conditions"
 	"github.com/vmware-tanzu/cartographer/pkg/logger"
 	"github.com/vmware-tanzu/cartographer/pkg/realizer/healthcheck"
 	"github.com/vmware-tanzu/cartographer/pkg/realizer/statuses"
@@ -124,7 +125,7 @@ func (r *realizer) Realize(ctx context.Context, resourceRealizer ResourceRealize
 		var additionalConditions []metav1.Condition
 		if (stampedObject == nil || template == nil) && previousResourceStatus != nil {
 			realizedResource = &previousResourceStatus.RealizedResource
-			if previousResourceStatusHealthyCondition := conditionList(previousResourceStatus.Conditions).ConditionWithType(v1alpha1.ResourceHealthy); previousResourceStatusHealthyCondition != nil {
+			if previousResourceStatusHealthyCondition := conditions.ConditionList(previousResourceStatus.Conditions).ConditionWithType(v1alpha1.ResourceHealthy); previousResourceStatusHealthyCondition != nil {
 				additionalConditions = []metav1.Condition{*previousResourceStatusHealthyCondition}
 			}
 		} else {
@@ -141,17 +142,6 @@ func (r *realizer) Realize(ctx context.Context, resourceRealizer ResourceRealize
 	}
 
 	return firstError
-}
-
-type conditionList []metav1.Condition
-
-func (c conditionList) ConditionWithType(conditionType string) *metav1.Condition {
-	for _, condition := range c {
-		if condition.Type == conditionType {
-			return &condition
-		}
-	}
-	return nil
 }
 
 func generateRealizedResource(resource OwnerResource, template templates.Template, stampedObject *unstructured.Unstructured, output *templates.Output, previousRealizedResource *v1alpha1.RealizedResource) *v1alpha1.RealizedResource {

--- a/tests/kuttl/delivery/deliverable-status/02-assert.yaml
+++ b/tests/kuttl/delivery/deliverable-status/02-assert.yaml
@@ -50,6 +50,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/delivery/deliverable/01-assert.yaml
+++ b/tests/kuttl/delivery/deliverable/01-assert.yaml
@@ -76,6 +76,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/delivery/deploy-w-bad-match/01-assert.yaml
+++ b/tests/kuttl/delivery/deploy-w-bad-match/01-assert.yaml
@@ -26,6 +26,9 @@ status:
       status: Unknown
       reason: ConditionNotMet
       message: "resource [deployer] condition not met: input [spec.value.some-key] and output [spec.value.bad-key] do not match: https://github.com/ekcasey/hello-world-ops != some-mismatching-value"
+    - type: ResourcesHealthy
+      status: "Unknown"
+      reason: HealthyConditionRule
     - type: Ready
       status: "Unknown"
       reason: ConditionNotMet

--- a/tests/kuttl/delivery/deploy-w-missing-match/01-assert.yaml
+++ b/tests/kuttl/delivery/deploy-w-missing-match/01-assert.yaml
@@ -26,6 +26,9 @@ status:
       status: Unknown
       reason: ConditionNotMet
       message: "resource [deployer] condition not met: could not find value on output [spec.value.some-missing-key]: jsonpath returned empty list: spec.value.some-missing-key"
+    - type: ResourcesHealthy
+      status: "Unknown"
+      reason: HealthyConditionRule
     - type: Ready
       status: Unknown
       reason: ConditionNotMet

--- a/tests/kuttl/delivery/options-with-labels/02-assert.yaml
+++ b/tests/kuttl/delivery/options-with-labels/02-assert.yaml
@@ -33,6 +33,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/delivery/options-with-metadata/02-assert.yaml
+++ b/tests/kuttl/delivery/options-with-metadata/02-assert.yaml
@@ -33,6 +33,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/delivery/options-with-values/02-assert.yaml
+++ b/tests/kuttl/delivery/options-with-values/02-assert.yaml
@@ -33,6 +33,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/delivery/options/02-assert.yaml
+++ b/tests/kuttl/delivery/options/02-assert.yaml
@@ -33,6 +33,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/delivery/params-delivery/01-assert.yaml
+++ b/tests/kuttl/delivery/params-delivery/01-assert.yaml
@@ -42,6 +42,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/supplychain/options-with-labels/02-assert.yaml
+++ b/tests/kuttl/supplychain/options-with-labels/02-assert.yaml
@@ -35,6 +35,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/supplychain/options-with-metadata/02-assert.yaml
+++ b/tests/kuttl/supplychain/options-with-metadata/02-assert.yaml
@@ -35,6 +35,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/supplychain/options-with-values/02-assert.yaml
+++ b/tests/kuttl/supplychain/options-with-values/02-assert.yaml
@@ -35,6 +35,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/supplychain/options/02-assert.yaml
+++ b/tests/kuttl/supplychain/options/02-assert.yaml
@@ -35,6 +35,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/supplychain/params-supply-chain/02-assert.yaml
+++ b/tests/kuttl/supplychain/params-supply-chain/02-assert.yaml
@@ -45,6 +45,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/supplychain/templates-refer-to-workload/02-assert.yaml
+++ b/tests/kuttl/supplychain/templates-refer-to-workload/02-assert.yaml
@@ -70,6 +70,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/supplychain/templates-ytt-bad-params/02-assert.yaml
+++ b/tests/kuttl/supplychain/templates-ytt-bad-params/02-assert.yaml
@@ -26,6 +26,9 @@ status:
       status: "False"
       reason: TemplateStampFailure
       message: "unable to stamp object for resource [params] in supply chain [responsible-ops---templates-ytt-bad-params]: unable to apply ytt template: ytt: Error: \n- key \"waciuma-com/quality\" not in struct\n    in <toplevel>\n      stdin.yml:8 |   best_name: #@ data.values.params[\"waciuma-com/quality\"]\n"
+    - type: ResourcesHealthy
+      status: "Unknown"
+      reason: HealthyConditionRule
     - type: Ready
       status: "False"
       reason: TemplateStampFailure

--- a/tests/kuttl/supplychain/templates-ytt/02-assert.yaml
+++ b/tests/kuttl/supplychain/templates-ytt/02-assert.yaml
@@ -78,6 +78,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/supplychain/unknown/02-assert.yaml
+++ b/tests/kuttl/supplychain/unknown/02-assert.yaml
@@ -26,6 +26,9 @@ status:
     - type: ResourcesSubmitted
       status: "Unknown"
       reason: MissingValueAtPath
+    - type: ResourcesHealthy
+      status: "Unknown"
+      reason: HealthyConditionRule
     - type: Ready
       status: "Unknown"
       reason: MissingValueAtPath

--- a/tests/kuttl/supplychain/unknown/03-assert.yaml
+++ b/tests/kuttl/supplychain/unknown/03-assert.yaml
@@ -34,6 +34,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/supplychain/values-cannot-be-interpolated/02-assert.yaml
+++ b/tests/kuttl/supplychain/values-cannot-be-interpolated/02-assert.yaml
@@ -24,6 +24,9 @@ status:
     - type: ResourcesSubmitted
       status: "Unknown"
       reason: MissingValueAtPath
+    - type: ResourcesHealthy
+      status: "Unknown"
+      reason: HealthyConditionRule
     - type: Ready
       status: "Unknown"
       reason: MissingValueAtPath
@@ -44,6 +47,9 @@ status:
     - type: ResourcesSubmitted
       status: "False"
       reason: TemplateStampFailure
+    - type: ResourcesHealthy
+      status: "Unknown"
+      reason: HealthyConditionRule
     - type: Ready
       status: "False"
       reason: TemplateStampFailure

--- a/tests/kuttl/supplychain/workload-multiple-labels-supply-chain-single-selector/02-assert.yaml
+++ b/tests/kuttl/supplychain/workload-multiple-labels-supply-chain-single-selector/02-assert.yaml
@@ -24,6 +24,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/supplychain/workload-status/02-assert.yaml
+++ b/tests/kuttl/supplychain/workload-status/02-assert.yaml
@@ -50,6 +50,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/supplychain/workload-supply-chain-hardcoded-templates/02-assert.yaml
+++ b/tests/kuttl/supplychain/workload-supply-chain-hardcoded-templates/02-assert.yaml
@@ -96,6 +96,9 @@ status:
     - type: ResourcesSubmitted
       status: "True"
       reason: ResourceSubmissionComplete
+    - type: ResourcesHealthy
+      status: "True"
+      reason: HealthyConditionRule
     - type: Ready
       status: "True"
       reason: Ready

--- a/tests/kuttl/supplychain/workload-supply-chain-malformed-templates/02-assert.yaml
+++ b/tests/kuttl/supplychain/workload-supply-chain-malformed-templates/02-assert.yaml
@@ -37,6 +37,9 @@ status:
     - type: ResourcesSubmitted
       status: "False"
       reason: "TemplateStampFailure"
+    - type: ResourcesHealthy
+      status: "Unknown"
+      reason: HealthyConditionRule
     - type: Ready
       status: "False"
       reason: "TemplateStampFailure"

--- a/tests/kuttl/supplychain/workload-supply-chain-template-cannot-be-applied/02-assert.yaml
+++ b/tests/kuttl/supplychain/workload-supply-chain-template-cannot-be-applied/02-assert.yaml
@@ -24,6 +24,9 @@ status:
     - type: ResourcesSubmitted
       status: "False"
       reason: "TemplateRejectedByAPIServer"
+    - type: ResourcesHealthy
+      status: "Unknown"
+      reason: HealthyConditionRule
     - type: Ready
       status: "False"
       reason: "TemplateRejectedByAPIServer"


### PR DESCRIPTION
## Changes proposed by this PR

Owners now report `ResourcesHealthy` condition which summarizes the `Healthy` condition of its owned resources.

When any resource has a `Healthy` condition with `Unknown` status, the status of `ResourcesHealthy` is `Unknown`.
If not, when any resource has a `Healthy` condition with `False` status, the status of `ResourcesHealthy` is `False`.
Else, all resources have a `Healthy` condition of `True` and  the status of `ResourcesHealthy` is `True`.

Objects stamped with `ClusterTemplate` without a `healthRule` are now only considered to have a `Healthy` with a status of `True` when the object is successfully created.

builds on PR #875 

updates #812

## Release Note

Owners report `ResourcesHealthy` condition to reflect overall `Healthy` condition of owned resources

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above 
- [] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
