### PR TITLE
Avoid bringing up a registry on a MACOS default port

### DIFF
--- a/hack/ci/trust-local-registry.sh
+++ b/hack/ci/trust-local-registry.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly local_registry=$(ip route get 8.8.8.8 | grep src | awk '{print $7}'):5000
+readonly local_registry=$(ip route get 8.8.8.8 | grep src | awk '{print $7}'):5001
 readonly config_file=/etc/docker/daemon.json
 
 echo "$(jq ". + {\"insecure-registries\": [\"$local_registry\"]}" $config_file)" >$config_file

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -21,7 +21,7 @@ ROOT=$(cd "$(dirname $0)"/.. && pwd)
 readonly ROOT
 
 readonly SCRATCH=${SCRATCH:-$(mktemp -d)}
-readonly REGISTRY=${REGISTRY:-"$($ROOT/hack/ip.py):5000"}
+readonly REGISTRY=${REGISTRY:-"$($ROOT/hack/ip.py):5001"}
 readonly RELEASE_DATE=${RELEASE_DATE:-$(TZ=UTC date +"%Y-%m-%dT%H:%M:%SZ")}
 
 readonly YTT_VERSION=0.39.0

--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -20,7 +20,7 @@ set -o pipefail
 # shellcheck disable=SC2155
 readonly DIR="$(cd "$(dirname "$0")" && pwd)"
 readonly HOST_ADDR=${HOST_ADDR:-$("$DIR"/ip.py)}
-readonly REGISTRY_PORT=${REGISTRY_PORT:-5000}
+readonly REGISTRY_PORT=${REGISTRY_PORT:-5001}
 readonly REGISTRY=${REGISTRY:-"${HOST_ADDR}:${REGISTRY_PORT}"}
 readonly KIND_IMAGE=${KIND_IMAGE:-kindest/node:v1.21.1}
 readonly RELEASE_VERSION=${RELEASE_VERSION:-""}

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -20,7 +20,7 @@ set -o pipefail
 # shellcheck disable=SC2155
 readonly DIR="$(cd "$(dirname "$0")" && pwd)"
 readonly HOST_ADDR=${HOST_ADDR:-$("$DIR"/ip.py)}
-readonly REGISTRY_PORT=${REGISTRY_PORT:-5000}
+readonly REGISTRY_PORT=${REGISTRY_PORT:-5001}
 readonly REGISTRY=${REGISTRY:-"${HOST_ADDR}:${REGISTRY_PORT}"}
 # shellcheck disable=SC2034  # This _should_ be marked as an extern but I clearly don't understand how it operates in github actions
 readonly DOCKER_CONFIG=${DOCKER_CONFIG:-"/tmp/cartographer-docker"}


### PR DESCRIPTION
Port 5000 is used by ControlCenter: https://developer.apple.com/forums/thread/682332
We now map 5001->5000 when creating the registry

Co-authored-by: Ciro da Silva da Costa <ciroscosta@vmware.com>
