### PR TITLE
907 realizer stamps out objects even though their dependencies havent been met yet

### DIFF
--- a/pkg/realizer/component.go
+++ b/pkg/realizer/component.go
@@ -144,8 +144,12 @@ func (r *resourceRealizer) Do(ctx context.Context, resource OwnerResource, bluep
 	}
 
 	stampContext := templates.StamperBuilder(r.owner, ownerTemplatingContext, labels)
+
+	fmt.Printf(">>>>>>>> Stamping Context for %s: %+v\n", resource.Name, stampContext)
+
 	stampedObject, err := stampContext.Stamp(ctx, template.GetResourceTemplate())
 	if err != nil {
+		fmt.Printf(">>>>>>>> Error for %s: %w\n", resource.Name, err)
 		log.Error(err, "failed to stamp resource")
 		return template, nil, nil, errors.StampError{
 			Err:           err,

--- a/pkg/realizer/realizer.go
+++ b/pkg/realizer/realizer.go
@@ -18,6 +18,7 @@ package realizer
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -117,6 +118,10 @@ func (r *realizer) Realize(ctx context.Context, resourceRealizer ResourceRealize
 		}
 
 		outs.AddOutput(resource.Name, out)
+
+		fmt.Println("---------------------------------")
+		fmt.Printf("out: %s: %+v\n", resource.Name, out)
+		fmt.Println("/\\/\\/\\/\\/\\/\\/\\/\\/\\/\\/\\/\\/\\/\\/\\/\\/\\/\\")
 
 		previousResourceStatus := resourceStatuses.GetPreviousResourceStatus(resource.Name)
 

--- a/tests/kuttl/supplychain/early-stamp-regression-2/00-assert.yaml
+++ b/tests/kuttl/supplychain/early-stamp-regression-2/00-assert.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterSupplyChain
+metadata:
+  name: early-stamp-sc-2
+status:
+  conditions:
+  - reason: Ready
+    status: "True"
+    type: TemplatesReady
+  - reason: Ready
+    status: "True"
+    type: Ready
+

--- a/tests/kuttl/supplychain/early-stamp-regression-2/00-service-account.yaml
+++ b/tests/kuttl/supplychain/early-stamp-regression-2/00-service-account.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-service-account
+secrets:
+  - name: my-service-account-secret
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-service-account-secret
+  annotations:
+    kubernetes.io/service-account.name: my-service-account
+data:
+  token: "ZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNklubFNWM1YxVDNSRldESnZVRE4wTUd0R1EzQmlVVlJOVWtkMFNGb3RYMGh2VUhKYU1FRnVOR0Y0WlRBaWZRLmV5SnBjM01pT2lKcmRXSmxjbTVsZEdWekwzTmxjblpwWTJWaFkyTnZkVzUwSWl3aWEzVmlaWEp1WlhSbGN5NXBieTl6WlhKMmFXTmxZV05qYjNWdWRDOXVZVzFsYzNCaFkyVWlPaUprWldaaGRXeDBJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpXTnlaWFF1Ym1GdFpTSTZJbTE1TFhOaExYUnZhMlZ1TFd4dVkzRndJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpYSjJhV05sTFdGalkyOTFiblF1Ym1GdFpTSTZJbTE1TFhOaElpd2lhM1ZpWlhKdVpYUmxjeTVwYnk5elpYSjJhV05sWVdOamIzVnVkQzl6WlhKMmFXTmxMV0ZqWTI5MWJuUXVkV2xrSWpvaU9HSXhNV1V3WldNdFlURTVOeTAwWVdNeUxXRmpORFF0T0RjelpHSmpOVE13TkdKbElpd2ljM1ZpSWpvaWMzbHpkR1Z0T25ObGNuWnBZMlZoWTJOdmRXNTBPbVJsWm1GMWJIUTZiWGt0YzJFaWZRLmplMzRsZ3hpTUtnd0QxUGFhY19UMUZNWHdXWENCZmhjcVhQMEE2VUV2T0F6ek9xWGhpUUdGN2poY3RSeFhmUVFJVEs0Q2tkVmZ0YW5SUjNPRUROTUxVMVBXNXVsV3htVTZTYkMzdmZKT3ozLVJPX3BOVkNmVW8tZURpblN1Wm53bjNzMjNjZU9KM3IzYk04cnBrMHZZZFgyRVlQRGItMnd4cjIzZ1RxUjVxZU5ULW11cS1qYktXVE8wYnRYVl9wVHNjTnFXUkZIVzJBVTVHYVBpbmNWVXg1bXExLXN0SFdOOGtjTG96OF96S2RnUnJGYV92clFjb3NWZzZCRW5MSEt2NW1fVEhaR3AybU8wYmtIV3J1Q2xEUDdLc0tMOFVaZWxvTDN4Y3dQa000VlBBb2V0bDl5MzlvUi1KbWh3RUlIcS1hX3BzaVh5WE9EQU44STcybEZpUSU="
+type: kubernetes.io/service-account-token

--- a/tests/kuttl/supplychain/early-stamp-regression-2/00-supply-chain.yaml
+++ b/tests/kuttl/supplychain/early-stamp-regression-2/00-supply-chain.yaml
@@ -1,0 +1,20 @@
+apiVersion: carto.run/v1alpha1
+kind: ClusterSupplyChain
+metadata:
+  name: early-stamp-sc-2
+spec:
+  selector:
+    integration-test: "early-stamp"
+  resources:
+    - name: first
+      templateRef:
+        kind: ClusterSourceTemplate
+        name: early-stamp-template-first-2
+
+    - name: second
+      templateRef:
+        kind: ClusterTemplate
+        name: early-stamp-template-second-2
+      sources:
+        - resource: first
+          name: source

--- a/tests/kuttl/supplychain/early-stamp-regression-2/00-templates.yaml
+++ b/tests/kuttl/supplychain/early-stamp-regression-2/00-templates.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterSourceTemplate
+metadata:
+  name: early-stamp-template-first-2
+spec:
+  urlPath: .data.url
+  revisionPath: .data.revision
+  template:
+    apiVersion: test.run/v1alpha1
+    kind: Test
+    metadata:
+      name: early-stamped-object-first-2
+    spec:
+      value:
+        a: thing
+
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: early-stamp-template-second-2
+spec:
+  template:
+    apiVersion: test.run/v1alpha1
+    kind: Test
+    metadata:
+      name: early-stamped-object-second-2
+    spec:
+      value:
+        a: $(source.url)$

--- a/tests/kuttl/supplychain/early-stamp-regression-2/01-assert.yaml
+++ b/tests/kuttl/supplychain/early-stamp-regression-2/01-assert.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: test.run/v1alpha1
+kind: Test
+metadata:
+  name: early-stamped-object-first-2
+spec:
+  value:
+    a: thing

--- a/tests/kuttl/supplychain/early-stamp-regression-2/01-workload.yaml
+++ b/tests/kuttl/supplychain/early-stamp-regression-2/01-workload.yaml
@@ -1,0 +1,8 @@
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  name: early-stamp-workload-2
+  labels:
+    integration-test: "early-stamp"
+spec:
+  serviceAccountName: my-service-account

--- a/tests/kuttl/supplychain/early-stamp-regression-2/02-errors.yaml
+++ b/tests/kuttl/supplychain/early-stamp-regression-2/02-errors.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: test.run/v1alpha1
+kind: Test
+metadata:
+  name: early-stamped-object-second-2

--- a/tests/kuttl/supplychain/early-stamp-regression/00-assert.yaml
+++ b/tests/kuttl/supplychain/early-stamp-regression/00-assert.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterSupplyChain
+metadata:
+  name: early-stamp-sc
+status:
+  conditions:
+  - reason: Ready
+    status: "True"
+    type: TemplatesReady
+  - reason: Ready
+    status: "True"
+    type: Ready
+

--- a/tests/kuttl/supplychain/early-stamp-regression/00-service-account.yaml
+++ b/tests/kuttl/supplychain/early-stamp-regression/00-service-account.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-service-account
+secrets:
+  - name: my-service-account-secret
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-service-account-secret
+  annotations:
+    kubernetes.io/service-account.name: my-service-account
+data:
+  token: "ZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNklubFNWM1YxVDNSRldESnZVRE4wTUd0R1EzQmlVVlJOVWtkMFNGb3RYMGh2VUhKYU1FRnVOR0Y0WlRBaWZRLmV5SnBjM01pT2lKcmRXSmxjbTVsZEdWekwzTmxjblpwWTJWaFkyTnZkVzUwSWl3aWEzVmlaWEp1WlhSbGN5NXBieTl6WlhKMmFXTmxZV05qYjNWdWRDOXVZVzFsYzNCaFkyVWlPaUprWldaaGRXeDBJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpXTnlaWFF1Ym1GdFpTSTZJbTE1TFhOaExYUnZhMlZ1TFd4dVkzRndJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpYSjJhV05sTFdGalkyOTFiblF1Ym1GdFpTSTZJbTE1TFhOaElpd2lhM1ZpWlhKdVpYUmxjeTVwYnk5elpYSjJhV05sWVdOamIzVnVkQzl6WlhKMmFXTmxMV0ZqWTI5MWJuUXVkV2xrSWpvaU9HSXhNV1V3WldNdFlURTVOeTAwWVdNeUxXRmpORFF0T0RjelpHSmpOVE13TkdKbElpd2ljM1ZpSWpvaWMzbHpkR1Z0T25ObGNuWnBZMlZoWTJOdmRXNTBPbVJsWm1GMWJIUTZiWGt0YzJFaWZRLmplMzRsZ3hpTUtnd0QxUGFhY19UMUZNWHdXWENCZmhjcVhQMEE2VUV2T0F6ek9xWGhpUUdGN2poY3RSeFhmUVFJVEs0Q2tkVmZ0YW5SUjNPRUROTUxVMVBXNXVsV3htVTZTYkMzdmZKT3ozLVJPX3BOVkNmVW8tZURpblN1Wm53bjNzMjNjZU9KM3IzYk04cnBrMHZZZFgyRVlQRGItMnd4cjIzZ1RxUjVxZU5ULW11cS1qYktXVE8wYnRYVl9wVHNjTnFXUkZIVzJBVTVHYVBpbmNWVXg1bXExLXN0SFdOOGtjTG96OF96S2RnUnJGYV92clFjb3NWZzZCRW5MSEt2NW1fVEhaR3AybU8wYmtIV3J1Q2xEUDdLc0tMOFVaZWxvTDN4Y3dQa000VlBBb2V0bDl5MzlvUi1KbWh3RUlIcS1hX3BzaVh5WE9EQU44STcybEZpUSU="
+type: kubernetes.io/service-account-token

--- a/tests/kuttl/supplychain/early-stamp-regression/00-supply-chain.yaml
+++ b/tests/kuttl/supplychain/early-stamp-regression/00-supply-chain.yaml
@@ -1,0 +1,20 @@
+apiVersion: carto.run/v1alpha1
+kind: ClusterSupplyChain
+metadata:
+  name: early-stamp-sc
+spec:
+  selector:
+    integration-test: "early-stamp"
+  resources:
+    - name: first
+      templateRef:
+        kind: ClusterSourceTemplate
+        name: early-stamp-template-first
+
+    - name: second
+      templateRef:
+        kind: ClusterTemplate
+        name: early-stamp-template-second
+      sources:
+        - resource: first
+          name: source

--- a/tests/kuttl/supplychain/early-stamp-regression/00-templates.yaml
+++ b/tests/kuttl/supplychain/early-stamp-regression/00-templates.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterSourceTemplate
+metadata:
+  name: early-stamp-template-first
+spec:
+  urlPath: .data.url
+  revisionPath: .data.revision
+  template:
+    apiVersion: test.run/v1alpha1
+    kind: Test
+    metadata:
+      name: early-stamped-object-first
+    spec:
+      value:
+        a: thing
+
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: early-stamp-template-second
+spec:
+  template:
+    apiVersion: test.run/v1alpha1
+    kind: Test
+    metadata:
+      name: early-stamped-object-second
+    spec:
+      value:
+        a: thing

--- a/tests/kuttl/supplychain/early-stamp-regression/01-assert.yaml
+++ b/tests/kuttl/supplychain/early-stamp-regression/01-assert.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: test.run/v1alpha1
+kind: Test
+metadata:
+  name: early-stamped-object-first
+spec:
+  value:
+    a: thing

--- a/tests/kuttl/supplychain/early-stamp-regression/01-errors.yaml
+++ b/tests/kuttl/supplychain/early-stamp-regression/01-errors.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: test.run/v1alpha1
+kind: Test
+metadata:
+  name: early-stamped-object-second
+spec:
+  value:
+    a: thing

--- a/tests/kuttl/supplychain/early-stamp-regression/01-workload.yaml
+++ b/tests/kuttl/supplychain/early-stamp-regression/01-workload.yaml
@@ -1,0 +1,8 @@
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  name: early-stamp-workload
+  labels:
+    integration-test: "early-stamp"
+spec:
+  serviceAccountName: my-service-account


### PR DESCRIPTION
Do not merge

Example of the original bug and why we think it's a wont-fix