### PR TITLE
Backport #937 to 0.4.x release branch

### DIFF
--- a/pkg/repository/cache_test.go
+++ b/pkg/repository/cache_test.go
@@ -59,30 +59,30 @@ var _ = Describe("Cache", func() {
 
 			Context("when the submitted object is not present in the cache", func() {
 				It("is false", func() {
-					Expect(cache.UnchangedSinceCachedFromList(submitted, existingObjsOnAPIServer)).To(BeNil())
+					Expect(cache.UnchangedSinceCachedFromList(submitted, existingObjsOnAPIServer, "A")).To(BeNil())
 				})
 			})
 
 			Context("when the submitted object differs from the cached submitted object", func() {
 				BeforeEach(func() {
-					cache.Set(submitted, persisted)
+					cache.Set(submitted, persisted, "A")
 				})
 
 				It("is false", func() {
 					newSubmission := submitted.DeepCopy()
 					newSubmission.SetLabels(map[string]string{"now-with": "funky-labels"})
-					Expect(cache.UnchangedSinceCachedFromList(newSubmission, existingObjsOnAPIServer)).To(BeNil())
+					Expect(cache.UnchangedSinceCachedFromList(newSubmission, existingObjsOnAPIServer, "A")).To(BeNil())
 				})
 			})
 
 			Context("when the submitted object is the same as the cached submitted object", func() {
 				BeforeEach(func() {
-					cache.Set(submitted, persisted)
+					cache.Set(submitted, persisted, "A")
 				})
 
 				Context("when the existing object has no spec", func() {
 					It("is false", func() {
-						Expect(cache.UnchangedSinceCachedFromList(submitted, existingObjsOnAPIServer)).To(BeNil())
+						Expect(cache.UnchangedSinceCachedFromList(submitted, existingObjsOnAPIServer, "A")).To(BeNil())
 					})
 				})
 
@@ -93,11 +93,11 @@ var _ = Describe("Cache", func() {
 
 					Context("when the persisted object has no spec", func() {
 						BeforeEach(func() {
-							cache.Set(submitted, persisted)
+							cache.Set(submitted, persisted, "A")
 						})
 
 						It("is false", func() {
-							Expect(cache.UnchangedSinceCachedFromList(submitted, existingObjsOnAPIServer)).To(BeNil())
+							Expect(cache.UnchangedSinceCachedFromList(submitted, existingObjsOnAPIServer, "A")).To(BeNil())
 						})
 					})
 
@@ -105,22 +105,26 @@ var _ = Describe("Cache", func() {
 						Context("when the existing object spec is the same as the cached submitted object spec", func() {
 							BeforeEach(func() {
 								persisted.UnstructuredContent()["spec"] = existingObjsOnAPIServer[0].UnstructuredContent()["spec"]
-								cache.Set(submitted, persisted)
+								cache.Set(submitted, persisted, "A")
 							})
 
-							It("is true", func() {
-								Expect(cache.UnchangedSinceCachedFromList(submitted, existingObjsOnAPIServer)).ToNot(BeNil())
+							It("is true for the same owner discriminant", func() {
+								Expect(cache.UnchangedSinceCachedFromList(submitted, existingObjsOnAPIServer, "A")).ToNot(BeNil())
+							})
+
+							It("is false for a different owner discriminant", func() {
+								Expect(cache.UnchangedSinceCachedFromList(submitted, existingObjsOnAPIServer, "SomethingElse")).To(BeNil())
 							})
 						})
 
 						Context("when the existing object spec differs from the cached submitted object spec", func() {
 							BeforeEach(func() {
 								persisted.UnstructuredContent()["spec"] = map[string]interface{}{"oh-wait": "this-spec-is-different"}
-								cache.Set(submitted, persisted)
+								cache.Set(submitted, persisted, "A")
 							})
 
 							It("is false", func() {
-								Expect(cache.UnchangedSinceCachedFromList(submitted, existingObjsOnAPIServer)).To(BeNil())
+								Expect(cache.UnchangedSinceCachedFromList(submitted, existingObjsOnAPIServer, "A")).To(BeNil())
 							})
 						})
 					})
@@ -140,14 +144,14 @@ var _ = Describe("Cache", func() {
 				persisted.SetGenerateName("")
 				persisted.UnstructuredContent()["spec"] = submitted.UnstructuredContent()["spec"]
 
-				cache.Set(submitted, persisted)
+				cache.Set(submitted, persisted, "")
 				existingObjsOnAPIServer = append(existingObjsOnAPIServer, persisted.DeepCopy())
 			})
 
 			It("the cache matches against the generateName instead", func() {
-				Expect(cache.UnchangedSinceCachedFromList(submitted, existingObjsOnAPIServer)).ToNot(BeNil())
+				Expect(cache.UnchangedSinceCachedFromList(submitted, existingObjsOnAPIServer, "")).ToNot(BeNil())
 				submitted.SetGenerateName("another-generate-name-")
-				Expect(cache.UnchangedSinceCachedFromList(submitted, existingObjsOnAPIServer)).To(BeNil())
+				Expect(cache.UnchangedSinceCachedFromList(submitted, existingObjsOnAPIServer, "")).To(BeNil())
 			})
 		})
 	})
@@ -168,7 +172,7 @@ var _ = Describe("Cache", func() {
 
 			Context("when the submitted object differs from the cached submitted object", func() {
 				BeforeEach(func() {
-					cache.Set(submitted, persisted)
+					cache.Set(submitted, persisted, "")
 				})
 
 				It("is false", func() {
@@ -180,7 +184,7 @@ var _ = Describe("Cache", func() {
 
 			Context("when the submitted object is the same as the cached submitted object", func() {
 				BeforeEach(func() {
-					cache.Set(submitted, persisted)
+					cache.Set(submitted, persisted, "")
 				})
 
 				Context("when the existing object has no spec", func() {
@@ -196,7 +200,7 @@ var _ = Describe("Cache", func() {
 
 					Context("when the persisted object has no spec", func() {
 						BeforeEach(func() {
-							cache.Set(submitted, persisted)
+							cache.Set(submitted, persisted, "")
 						})
 
 						It("is false", func() {
@@ -208,7 +212,7 @@ var _ = Describe("Cache", func() {
 						Context("when the existing object spec is the same as the cached submitted object spec", func() {
 							BeforeEach(func() {
 								persisted.UnstructuredContent()["spec"] = existingObjOnAPIServer.UnstructuredContent()["spec"]
-								cache.Set(submitted, persisted)
+								cache.Set(submitted, persisted, "")
 							})
 
 							It("is true", func() {
@@ -219,7 +223,7 @@ var _ = Describe("Cache", func() {
 						Context("when the existing object spec differs from the cached submitted object spec", func() {
 							BeforeEach(func() {
 								persisted.UnstructuredContent()["spec"] = map[string]interface{}{"oh-wait": "this-spec-is-different"}
-								cache.Set(submitted, persisted)
+								cache.Set(submitted, persisted, "")
 							})
 
 							It("is false", func() {
@@ -243,7 +247,7 @@ var _ = Describe("Cache", func() {
 				persisted.SetGenerateName("")
 				persisted.UnstructuredContent()["spec"] = submitted.UnstructuredContent()["spec"]
 
-				cache.Set(submitted, persisted)
+				cache.Set(submitted, persisted, "")
 				existingObjsOnAPIServer = persisted.DeepCopy()
 			})
 

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -501,16 +501,16 @@ func (r *repository) GetScheme() *runtime.Scheme {
 
 func buildOwnerDiscriminant(labels map[string]string) string {
 	var discriminantComponents []string
-	for key, value := range labels {
-		discriminantComponents = insertSorted(discriminantComponents, fmt.Sprintf("{%s:%s}", key, value))
-	}
-	return strings.Join(discriminantComponents, "")
-}
 
-func insertSorted(ss []string, s string) []string {
-	i := sort.SearchStrings(ss, s)
-	ss = append(ss, "")
-	copy(ss[i+1:], ss[i:])
-	ss[i] = s
-	return ss
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		discriminantComponents = append(discriminantComponents, fmt.Sprintf("{%s:%s}", k, labels[k]))
+	}
+
+	return strings.Join(discriminantComponents, "")
 }

--- a/pkg/repository/repositoryfakes/fake_repo_cache.go
+++ b/pkg/repository/repositoryfakes/fake_repo_cache.go
@@ -9,11 +9,12 @@ import (
 )
 
 type FakeRepoCache struct {
-	SetStub        func(*unstructured.Unstructured, *unstructured.Unstructured)
+	SetStub        func(*unstructured.Unstructured, *unstructured.Unstructured, string)
 	setMutex       sync.RWMutex
 	setArgsForCall []struct {
 		arg1 *unstructured.Unstructured
 		arg2 *unstructured.Unstructured
+		arg3 string
 	}
 	UnchangedSinceCachedStub        func(*unstructured.Unstructured, *unstructured.Unstructured) *unstructured.Unstructured
 	unchangedSinceCachedMutex       sync.RWMutex
@@ -27,11 +28,12 @@ type FakeRepoCache struct {
 	unchangedSinceCachedReturnsOnCall map[int]struct {
 		result1 *unstructured.Unstructured
 	}
-	UnchangedSinceCachedFromListStub        func(*unstructured.Unstructured, []*unstructured.Unstructured) *unstructured.Unstructured
+	UnchangedSinceCachedFromListStub        func(*unstructured.Unstructured, []*unstructured.Unstructured, string) *unstructured.Unstructured
 	unchangedSinceCachedFromListMutex       sync.RWMutex
 	unchangedSinceCachedFromListArgsForCall []struct {
 		arg1 *unstructured.Unstructured
 		arg2 []*unstructured.Unstructured
+		arg3 string
 	}
 	unchangedSinceCachedFromListReturns struct {
 		result1 *unstructured.Unstructured
@@ -43,17 +45,18 @@ type FakeRepoCache struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeRepoCache) Set(arg1 *unstructured.Unstructured, arg2 *unstructured.Unstructured) {
+func (fake *FakeRepoCache) Set(arg1 *unstructured.Unstructured, arg2 *unstructured.Unstructured, arg3 string) {
 	fake.setMutex.Lock()
 	fake.setArgsForCall = append(fake.setArgsForCall, struct {
 		arg1 *unstructured.Unstructured
 		arg2 *unstructured.Unstructured
-	}{arg1, arg2})
+		arg3 string
+	}{arg1, arg2, arg3})
 	stub := fake.SetStub
-	fake.recordInvocation("Set", []interface{}{arg1, arg2})
+	fake.recordInvocation("Set", []interface{}{arg1, arg2, arg3})
 	fake.setMutex.Unlock()
 	if stub != nil {
-		fake.SetStub(arg1, arg2)
+		fake.SetStub(arg1, arg2, arg3)
 	}
 }
 
@@ -63,17 +66,17 @@ func (fake *FakeRepoCache) SetCallCount() int {
 	return len(fake.setArgsForCall)
 }
 
-func (fake *FakeRepoCache) SetCalls(stub func(*unstructured.Unstructured, *unstructured.Unstructured)) {
+func (fake *FakeRepoCache) SetCalls(stub func(*unstructured.Unstructured, *unstructured.Unstructured, string)) {
 	fake.setMutex.Lock()
 	defer fake.setMutex.Unlock()
 	fake.SetStub = stub
 }
 
-func (fake *FakeRepoCache) SetArgsForCall(i int) (*unstructured.Unstructured, *unstructured.Unstructured) {
+func (fake *FakeRepoCache) SetArgsForCall(i int) (*unstructured.Unstructured, *unstructured.Unstructured, string) {
 	fake.setMutex.RLock()
 	defer fake.setMutex.RUnlock()
 	argsForCall := fake.setArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeRepoCache) UnchangedSinceCached(arg1 *unstructured.Unstructured, arg2 *unstructured.Unstructured) *unstructured.Unstructured {
@@ -138,7 +141,7 @@ func (fake *FakeRepoCache) UnchangedSinceCachedReturnsOnCall(i int, result1 *uns
 	}{result1}
 }
 
-func (fake *FakeRepoCache) UnchangedSinceCachedFromList(arg1 *unstructured.Unstructured, arg2 []*unstructured.Unstructured) *unstructured.Unstructured {
+func (fake *FakeRepoCache) UnchangedSinceCachedFromList(arg1 *unstructured.Unstructured, arg2 []*unstructured.Unstructured, arg3 string) *unstructured.Unstructured {
 	var arg2Copy []*unstructured.Unstructured
 	if arg2 != nil {
 		arg2Copy = make([]*unstructured.Unstructured, len(arg2))
@@ -149,13 +152,14 @@ func (fake *FakeRepoCache) UnchangedSinceCachedFromList(arg1 *unstructured.Unstr
 	fake.unchangedSinceCachedFromListArgsForCall = append(fake.unchangedSinceCachedFromListArgsForCall, struct {
 		arg1 *unstructured.Unstructured
 		arg2 []*unstructured.Unstructured
-	}{arg1, arg2Copy})
+		arg3 string
+	}{arg1, arg2Copy, arg3})
 	stub := fake.UnchangedSinceCachedFromListStub
 	fakeReturns := fake.unchangedSinceCachedFromListReturns
-	fake.recordInvocation("UnchangedSinceCachedFromList", []interface{}{arg1, arg2Copy})
+	fake.recordInvocation("UnchangedSinceCachedFromList", []interface{}{arg1, arg2Copy, arg3})
 	fake.unchangedSinceCachedFromListMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -169,17 +173,17 @@ func (fake *FakeRepoCache) UnchangedSinceCachedFromListCallCount() int {
 	return len(fake.unchangedSinceCachedFromListArgsForCall)
 }
 
-func (fake *FakeRepoCache) UnchangedSinceCachedFromListCalls(stub func(*unstructured.Unstructured, []*unstructured.Unstructured) *unstructured.Unstructured) {
+func (fake *FakeRepoCache) UnchangedSinceCachedFromListCalls(stub func(*unstructured.Unstructured, []*unstructured.Unstructured, string) *unstructured.Unstructured) {
 	fake.unchangedSinceCachedFromListMutex.Lock()
 	defer fake.unchangedSinceCachedFromListMutex.Unlock()
 	fake.UnchangedSinceCachedFromListStub = stub
 }
 
-func (fake *FakeRepoCache) UnchangedSinceCachedFromListArgsForCall(i int) (*unstructured.Unstructured, []*unstructured.Unstructured) {
+func (fake *FakeRepoCache) UnchangedSinceCachedFromListArgsForCall(i int) (*unstructured.Unstructured, []*unstructured.Unstructured, string) {
 	fake.unchangedSinceCachedFromListMutex.RLock()
 	defer fake.unchangedSinceCachedFromListMutex.RUnlock()
 	argsForCall := fake.unchangedSinceCachedFromListArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeRepoCache) UnchangedSinceCachedFromListReturns(result1 *unstructured.Unstructured) {


### PR DESCRIPTION
## Changes proposed by this PR

Prevents resources stamped by a RunTemplate but different Runnables from being conflated.
This prevents Cartographer from mistakenly stamping the resources endlessly for each Runnable in turn.

Includes performance and testing improvements from #937 

[Fixes #930]

## Release Note

Runnable stamped resources now also key by their labels in the cache, ensuring stamped resources from different Runnables sharing the same RunTemplate do not cause endless resources to be stamped [Fix https://github.com/vmware-tanzu/cartographer/issues/930]

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above 
- ~[ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->~
