### PR TITLE
config: fix misnamed resource in clusterrole

### DIFF
--- a/config/rbac/rbac.yaml
+++ b/config/rbac/rbac.yaml
@@ -83,7 +83,7 @@ rules:
       - carto.run
     resources:
       - workloads
-      - deliveries
+      - deliverables
     verbs:
       - create
       - update
@@ -105,7 +105,7 @@ rules:
       - carto.run
     resources:
       - workloads
-      - deliveries
+      - deliverables
     verbs:
       - get
       - list


### PR DESCRIPTION
## Changes proposed by this PR

the resource that we're authorizing those that bound to this role should
actually be `deliverables` (aka the owner object for everything
clusterdelivery) as opposed to "deliveries" (there is no such thing as a
"delivery" resource).

```console
$ k api-resources  | grep carto | grep deliver
clusterdeliveries ..  ClusterDelivery
deliverables      ..  Deliverable
```

## Release Note

* Fix misnamed resource in clusterroles

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [ ] Removed non-atomic or `wip` commits
- [ ] Filled in the [Release Note](#Release-Note) section above 
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
