### PR TITLE
Make a meaningful change for upgrade test

### DIFF
--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -243,7 +243,11 @@ update_source(){
   log "updating source repo"
 
   pushd "$source_dir/$SOURCE_REPO"
-    sed -i '' 's/hello world/hello universe/g' main.go
+    if [ "$(uname)" == "Darwin" ]; then
+      sed -i '' 's/hello world/hello universe/g' main.go
+    else
+      sed 's/hello world/hello universe/' main.go
+    fi
     git config user.email "gitops-user@example.com"
     git config user.name "Gitops User"
     git add .

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -243,11 +243,11 @@ update_source(){
   log "updating source repo"
 
   pushd "$source_dir/$SOURCE_REPO"
-    echo "meaningless change" >> README.md
+    sed -i '' 's/hello world/hello universe/g' main.go
     git config user.email "gitops-user@example.com"
     git config user.name "Gitops User"
     git add .
-    git commit -m "Meaningless change"
+    git commit -m "Not a meaningless change"
     git push origin $SOURCE_BRANCH
   popd
 }

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -246,7 +246,7 @@ update_source(){
     if [ "$(uname)" == "Darwin" ]; then
       sed -i '' 's/hello world/hello universe/g' main.go
     else
-      sed 's/hello world/hello universe/' main.go
+      sed -i 's/hello world/hello universe/g' main.go
     fi
     git config user.email "gitops-user@example.com"
     git config user.name "Gitops User"


### PR DESCRIPTION
Previously, we were making a change to README.md. This is no longer triggering a new image to be built. This actually makes sense that it should only trigger on a meaningful change to the source code. 

Root cause for the change: https://github.com/paketo-buildpacks/go-build/pull/335


Co-authored-by: Rasheed Abdul-Aziz <rabdulaziz@vmware.com>
