### PR TITLE
stamper: preserve empty array when stamping

### DIFF
--- a/pkg/templates/stamper.go
+++ b/pkg/templates/stamper.go
@@ -120,6 +120,10 @@ func (s *Stamper) recursivelyEvaluateTemplates(jsonValue interface{}, loopDetect
 		}
 		return stampedMap, nil
 	case []interface{}:
+		if len(typedJSONValue) == 0 {
+			return typedJSONValue, nil
+		}
+
 		var stampedSlice []interface{}
 		for _, sliceElement := range typedJSONValue {
 			stampedElement, err := s.recursivelyEvaluateTemplates(sliceElement, loopDetector)

--- a/pkg/templates/stamper_test.go
+++ b/pkg/templates/stamper_test.go
@@ -210,6 +210,9 @@ var _ = Describe("Stamper", func() {
 			Entry(`Single tag, array value and type preserved, nested tags evaluated`,
 				`$(params.sub)$`, `["foo", "$(params['extra-for-nested'])$"]`, []interface{}{"foo", "nested"}, ""),
 
+			Entry(`Single tag, empty array value preserved`,
+				`$(params.sub)$`, `["foo", []]`, []interface{}{"foo", []interface{}{}}, ""),
+
 			Entry(`Multiple tags, result becomes a string`,
 				`$(params.sub)$$(params.sub)$`, `5`, "55", ""),
 


### PR DESCRIPTION

## Changes proposed by this PR

- update the stamping code related to `spec.template` to keep empty slices as empty slices rather than `nil`

when performing the recursive evaluation of the objects we stamp when
using `spec.template: {...}`, we used to always have a nil var that
would be instantiated when appending to it, but given that with 0-sized
slices we wouldn't get into the loop and thus never initialize, we'd
effectively always be transformating `[]` into `nil`.

`[]` -> `nil` is problematic specially when using `Runnable` with Tekton
as parameters that should be of type `array` but are initialized with
`[]` from the Runnable side would end up being transformed into `nil`
which is badly handled by tekton (it transforms `nil` -> `""`, which
goes against the validation of a task that expects an array).

e.g., consider the following Runnable:

```yaml
apiVersion: carto.run/v1alpha1
kind: Runnable
metadata:
  name: tester
spec:
  runTemplateRef:
    name: tekton-taskrun

  inputs:
    taskRef:
      name: test
    params:
      - name: foo
        value: []         #! empty slice
```

and the following `ClusterRunTemplate` that just carries that `spec.inputs.params` down to a TaskRun:

```yaml
---
apiVersion: carto.run/v1alpha1
kind: ClusterRunTemplate
metadata:
  name: tekton-taskrun
spec:
  template:
    apiVersion: tekton.dev/v1beta1
    kind: TaskRun
    metadata:
      generateName: test-
    spec:
      taskRef: $(runnable.spec.inputs.taskRef)$
      params: $(runnable.spec.inputs.params)$             #! <<<<<
```

what we'd expect? a TaskRun like so:

```yaml
    apiVersion: tekton.dev/v1beta1
    kind: TaskRun
    metadata:
      generateName: test-
    spec:
      taskRef: $(runnable.spec.inputs.taskRef)$
      params:
        - name: foo
           value: []
```

however, what we _actually_ get before this PR:

```yaml
    apiVersion: tekton.dev/v1beta1
    kind: TaskRun
    metadata:
      generateName: test-
    spec:
      taskRef: $(runnable.spec.inputs.taskRef)$
      params:
        - name: foo
           value: null
```

while that in itself is something that we should fix regardless (as it'd be surprising to go from `[]` -> `~`), in practice it's even more important considering that it _could_ be fine if Tekton treated `null` as a valid input for an array-typed param, that's not really the case: see [params_types.go](https://github.com/tektoncd/pipeline/blob/0741289847dc098f192ad9d75e040a50d9540cf6/pkg/apis/pipeline/v1beta1/param_types.go#L174-L182)


## Release Note

- Fix misplaced conversion of empty slices into null when using jsonpath-based templating

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [ ] Removed non-atomic or `wip` commits
- [ ] Filled in the [Release Note](#Release-Note) section above 
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
