### PR TITLE
config: prefix generic objects (validatingwebhook and issuer)

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -17,7 +17,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
-  name: cartographer-validating-webhook-configuration
+  name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1beta1

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -17,7 +17,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
-  name: validating-webhook-configuration
+  name: cartographer-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1beta1

--- a/config/webhook/support.yaml
+++ b/config/webhook/support.yaml
@@ -25,14 +25,14 @@ spec:
     - cartographer-webhook.cartographer-system.svc.cluster.local
   issuerRef:
     kind: Issuer
-    name: selfsigned-issuer
+    name: cartographer-selfsigned-issuer
   secretName: cartographer-webhook
 
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: selfsigned-issuer
+  name: cartographer-selfsigned-issuer
   namespace: cartographer-system
 spec:
   selfSigned: {}

--- a/hack/overlays/webhook-configuration.yaml
+++ b/hack/overlays/webhook-configuration.yaml
@@ -21,6 +21,7 @@ metadata:
   #@overlay/match missing_ok=True
   annotations:
     cert-manager.io/inject-ca-from: cartographer-system/cartographer-webhook
+  name: cartographer-validating-webhook-configuration
 
 webhooks:
   #@overlay/match by=overlay.all, expects="1+"


### PR DESCRIPTION

## Changes proposed by this PR

- config: prefix issuer w/ cartographer-

    despite the object being namespace-scoped, it's such a generic name that
    it makes sense to have it prefixed with `cartographer-` so that we're
    able to carry the component nomenclature.

- config: prefix cluster-scoped validatingwhook

    given that the ValidatingWebhookConfiguration we have (previously named
    `validating-webhook-configuration`) has a high risk of colliding with
    another package, prefix it with `cartographer-` to lower those chances.


closes #992


## Release Note

- prefix cluster-scoped validatingwebhook with `cartographer` to avoid conflicts with other validating webhook configurations
- prefix issues with `cartographer-` to avoid potential collisions in the cartographer-system namespace

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [ ] Removed non-atomic or `wip` commits
- [ ] Filled in the [Release Note](#Release-Note) section above 
- [ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->
