### PR TITLE
Deleting objects emits StampedObjectRemoved event

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 require (
 	github.com/google/gnostic v0.6.9
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/klog/v2 v2.70.1
 )
 
 require (
@@ -92,7 +93,6 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/component-base v0.25.0 // indirect
-	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -17,3 +17,4 @@ package events
 const NormalType = "Normal"
 
 const StampedObjectAppliedReason = "StampedObjectApplied"
+const StampedObjectRemovedReason = "StampedObjectRemoved"

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -87,6 +87,14 @@ func (r *repository) Delete(ctx context.Context, objToDelete *unstructured.Unstr
 	}
 
 	log.V(logger.DEBUG).Info("object deleted successfully")
+	qualifiedResourceName, err := utils.QualifiedResourceName(objToDelete, r.cl.RESTMapper())
+	if err != nil {
+		log.V(logger.DEBUG).Error(err, "cannot find rest mapping for deleted stamped object", "object", objToDelete)
+	} else {
+		rec := events.FromContextOrDie(ctx)
+		rec.Eventf(events.NormalType, events.StampedObjectRemovedReason, "Deleted object [%s]", qualifiedResourceName)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Changes proposed by this PR

Emit StampedObjectRemoved event when garbage collecting stamped runnable resources or orphaned resources.

Updates #850

## Release Note

Deleting objects emits StampedObjectRemoved event

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above 
- ~[ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->~
