### PR TITLE
Fix ytt failing test with version 0.42 of ytt

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -40,6 +40,11 @@ jobs:
 
       - name: setup carvel tooling binaries
         uses: vmware-tanzu/carvel-setup-action@v1
+        with:
+          ytt: v0.42.0 # Todo unlock as soon as 0.43 is working.
+
+      - run: |
+             ytt version
 
       - name: run source checks
         uses: ./.github/actions/source-checks


### PR DESCRIPTION
Fix ytt failing test with version 0.42 of ytt
- we currently ship with 0.42
- we need to work out what's actually wrong with 0.43
- includes version display step for debug in the future