### PR TITLE
Make OwnerEventRecorder.ResourceEventf more defensive

### DIFF
--- a/pkg/events/owner_recorder.go
+++ b/pkg/events/owner_recorder.go
@@ -76,10 +76,14 @@ func (o ownerEventRecorder) Eventf(eventtype, reason, messageFmt string, args ..
 }
 
 func (o ownerEventRecorder) ResourceEventf(eventtype, reason, messageFmt string, resource *unstructured.Unstructured, args ...interface{}) {
-	qualifiedResourceWithName, err := utils.GetQualifiedResourceWithName(o.mapper, resource)
-	if err != nil {
-		o.log.V(logger.DEBUG).Error(err, "cannot find rest mapping for resource", "resource", resource)
-		return
+	qualifiedResourceWithName := "<nil>"
+	if resource != nil {
+		var mappingErr error
+		qualifiedResourceWithName, mappingErr = utils.GetQualifiedResourceWithName(o.mapper, resource)
+		if mappingErr != nil {
+			o.log.V(logger.DEBUG).Error(mappingErr, "cannot find rest mapping for resource", "resource", resource)
+			return
+		}
 	}
 	messageFmt = strings.ReplaceAll(messageFmt, QualifiedResourceNameToken, qualifiedResourceWithName)
 	o.rec.Eventf(o.obj, eventtype, reason, messageFmt, args...)

--- a/pkg/events/owner_recorder_test.go
+++ b/pkg/events/owner_recorder_test.go
@@ -101,5 +101,17 @@ var _ = Describe("OwnerRecorder", func() {
 				Expect(out).To(Say(`cannot find rest mapping for resource.*"apiVersion":"example.com/v1".*"kind":"foo".*"name":"the-resource"`))
 			})
 		})
+
+		It("handles nil stamped object gracefully", func() {
+			rec.ResourceEventf("Normal", "EggsNil", "Resource [%Q] might panic without a nil check!", nil)
+
+			Expect(fakeRecorder.EventfCallCount()).To(Equal(1))
+			eventObject, eventType, reason, messageFormat, eventMessageArgs := fakeRecorder.EventfArgsForCall(0)
+			Expect(eventObject).To(Equal(ownerObject))
+			Expect(eventType).To(Equal("Normal"))
+			Expect(reason).To(Equal("EggsNil"))
+			Expect(messageFormat).To(Equal(`Resource [<nil>] might panic without a nil check!`))
+			Expect(eventMessageArgs).To(BeEmpty())
+		})
 	})
 })


### PR DESCRIPTION
## Changes proposed by this PR

Anticipate that callers may not always appreciate that the resource passed to ResourceEventf may be `nil` and handle this gracefully.

Fixes #1085 

## Release Note

Events pertaining to blueprint resources where a resource may nil no longer cause panics

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above 
- ~[ ] Modified the docs to match changes <!-- TBD: reference doc editing guidance -->~
