### PR TITLE
fix: Resource with option must report templateRefName

### DIFF
--- a/pkg/realizer/component.go
+++ b/pkg/realizer/component.go
@@ -74,7 +74,7 @@ func NewResourceRealizerBuilder(repositoryBuilder repository.RepositoryBuilder, 
 	}
 }
 
-func (r *resourceRealizer) Do(ctx context.Context, resource OwnerResource, blueprintName string, outputs Outputs, mapper meta.RESTMapper) (templates.Reader, *unstructured.Unstructured, *templates.Output, bool, error) {
+func (r *resourceRealizer) Do(ctx context.Context, resource OwnerResource, blueprintName string, outputs Outputs, mapper meta.RESTMapper) (templates.Reader, *unstructured.Unstructured, *templates.Output, bool, string, error) {
 	log := logr.FromContextOrDiscard(ctx).WithValues("template", resource.TemplateRef)
 	ctx = logr.NewContext(ctx, log)
 
@@ -98,7 +98,7 @@ func (r *resourceRealizer) Do(ctx context.Context, resource OwnerResource, bluep
 		var err error
 		templateOption, err = r.findMatchingTemplateOption(resource, blueprintName)
 		if err != nil {
-			return nil, nil, nil, passThrough, err
+			return nil, nil, nil, passThrough, templateName, err
 		}
 		if templateOption.PassThrough != "" {
 			passThrough = true
@@ -115,7 +115,7 @@ func (r *resourceRealizer) Do(ctx context.Context, resource OwnerResource, bluep
 		stampReader, err = stamp.NewPassThroughReader(resource.TemplateRef.Kind, templateOption.PassThrough, inputGenerator)
 		if err != nil {
 			log.Error(err, "failed to create new stamp pass through reader")
-			return nil, nil, nil, passThrough, fmt.Errorf("failed to create new stamp pass through reader: %w", err)
+			return nil, nil, nil, passThrough, templateName, fmt.Errorf("failed to create new stamp pass through reader: %w", err)
 		}
 
 		output, err = stampReader.Output(stampedObject)
@@ -128,7 +128,7 @@ func (r *resourceRealizer) Do(ctx context.Context, resource OwnerResource, bluep
 		apiTemplate, err = r.systemRepo.GetTemplate(ctx, templateName, resource.TemplateRef.Kind)
 		if err != nil {
 			log.Error(err, "failed to get cluster template")
-			return nil, nil, nil, passThrough, errors.GetTemplateError{
+			return nil, nil, nil, passThrough, templateName, errors.GetTemplateError{
 				Err:           err,
 				ResourceName:  resource.Name,
 				TemplateName:  templateName,
@@ -140,7 +140,7 @@ func (r *resourceRealizer) Do(ctx context.Context, resource OwnerResource, bluep
 		template, err = templates.NewReaderFromAPI(apiTemplate)
 		if err != nil {
 			log.Error(err, "failed to get cluster template")
-			return nil, nil, nil, passThrough, fmt.Errorf("failed to get cluster template [%+v]: %w", resource.TemplateRef, err)
+			return nil, nil, nil, passThrough, templateName, fmt.Errorf("failed to get cluster template [%+v]: %w", resource.TemplateRef, err)
 		}
 
 		labels := r.resourceLabeler(resource)
@@ -149,7 +149,7 @@ func (r *resourceRealizer) Do(ctx context.Context, resource OwnerResource, bluep
 		stampedObject, err = stamper.Stamp(ctx, template.GetResourceTemplate())
 		if err != nil {
 			log.Error(err, "failed to stamp resource")
-			return template, nil, nil, passThrough, errors.StampError{
+			return template, nil, nil, passThrough, templateName, errors.StampError{
 				Err:           err,
 				TemplateName:  templateName,
 				TemplateKind:  resource.TemplateRef.Kind,
@@ -162,14 +162,14 @@ func (r *resourceRealizer) Do(ctx context.Context, resource OwnerResource, bluep
 		stampReader, err = stamp.NewReader(apiTemplate, inputGenerator)
 		if err != nil {
 			log.Error(err, "failed to create new stamp reader")
-			return nil, nil, nil, passThrough, fmt.Errorf("failed to create new stamp reader: %w", err)
+			return nil, nil, nil, passThrough, templateName, fmt.Errorf("failed to create new stamp reader: %w", err)
 		}
 
 		if template.GetLifecycle().IsImmutable() {
 			err = r.ownerRepo.EnsureImmutableObjectExistsOnCluster(ctx, stampedObject, labels)
 			if err != nil {
 				log.Error(err, "failed to ensure object exists on cluster", "object", stampedObject)
-				return template, nil, nil, passThrough, errors.ApplyStampedObjectError{
+				return template, nil, nil, passThrough, templateName, errors.ApplyStampedObjectError{
 					Err:           err,
 					StampedObject: stampedObject,
 					ResourceName:  resource.Name,
@@ -181,7 +181,7 @@ func (r *resourceRealizer) Do(ctx context.Context, resource OwnerResource, bluep
 			allRunnableStampedObjects, err = r.ownerRepo.ListUnstructured(ctx, stampedObject.GroupVersionKind(), stampedObject.GetNamespace(), labels)
 			if err != nil {
 				log.Error(err, "failed to list objects")
-				return template, nil, nil, passThrough, errors.ListCreatedObjectsError{
+				return template, nil, nil, passThrough, templateName, errors.ListCreatedObjectsError{
 					Err:       err,
 					Namespace: stampedObject.GetNamespace(),
 					Labels:    labels,
@@ -218,7 +218,7 @@ func (r *resourceRealizer) Do(ctx context.Context, resource OwnerResource, bluep
 			err = r.ownerRepo.EnsureMutableObjectExistsOnCluster(ctx, stampedObject)
 			if err != nil {
 				log.Error(err, "failed to ensure object exists on cluster", "object", stampedObject)
-				return template, nil, nil, passThrough, errors.ApplyStampedObjectError{
+				return template, nil, nil, passThrough, templateName, errors.ApplyStampedObjectError{
 					Err:           err,
 					StampedObject: stampedObject,
 					ResourceName:  resource.Name,
@@ -245,7 +245,7 @@ func (r *resourceRealizer) Do(ctx context.Context, resource OwnerResource, bluep
 	}
 
 	if err != nil {
-		return template, stampedObject, nil, passThrough, errors.RetrieveOutputError{
+		return template, stampedObject, nil, passThrough, templateName, errors.RetrieveOutputError{
 			Err:               err,
 			ResourceName:      resource.Name,
 			StampedObject:     stampedObject,
@@ -256,7 +256,7 @@ func (r *resourceRealizer) Do(ctx context.Context, resource OwnerResource, bluep
 		}
 	}
 
-	return template, stampedObject, output, passThrough, nil
+	return template, stampedObject, output, passThrough, templateName, nil
 }
 
 func (r *resourceRealizer) findMatchingTemplateOption(resource OwnerResource, supplyChainName string) (v1alpha1.TemplateOption, error) {

--- a/pkg/realizer/component_test.go
+++ b/pkg/realizer/component_test.go
@@ -211,10 +211,11 @@ var _ = Describe("Resource", func() {
 				})
 
 				It("creates a stamped object and returns the outputs and stampedObjects", func() {
-					template, returnedStampedObject, out, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+					template, returnedStampedObject, out, isPassThrough, templateRefName, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(template).ToNot(BeNil())
 					Expect(isPassThrough).To(BeFalse())
+					Expect(templateRefName).To(Equal("image-template-1"))
 					Expect(returnedStampedObject.Object).To(Equal(expectedObject.Object))
 
 					Expect(fakeOwnerRepo.EnsureMutableObjectExistsOnClusterCallCount()).To(Equal(1))
@@ -271,10 +272,11 @@ var _ = Describe("Resource", func() {
 						})
 
 						It("creates a stamped object and returns the outputs and stampedObjects", func() {
-							template, returnedStampedObject, out, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+							template, returnedStampedObject, out, isPassThrough, templateRefName, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 							Expect(err).ToNot(HaveOccurred())
 							Expect(template).ToNot(BeNil())
 							Expect(isPassThrough).To(BeFalse())
+							Expect(templateRefName).To(Equal("image-template-1"))
 							Expect(returnedStampedObject.Object).To(Equal(expectedObject.Object))
 
 							Expect(fakeOwnerRepo.EnsureImmutableObjectExistsOnClusterCallCount()).To(Equal(1))
@@ -311,9 +313,10 @@ var _ = Describe("Resource", func() {
 						})
 
 						It("returns ListCreatedObjectsError", func() {
-							template, _, _, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+							template, _, _, isPassThrough, templateRefName, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 							Expect(template).ToNot(BeNil())
 							Expect(isPassThrough).To(BeFalse())
+							Expect(templateRefName).To(Equal("image-template-1"))
 
 							Expect(err).To(HaveOccurred())
 							Expect(err.Error()).To(ContainSubstring("some error"))
@@ -327,9 +330,10 @@ var _ = Describe("Resource", func() {
 					})
 
 					It("returns ApplyStampedObjectError", func() {
-						template, _, _, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+						template, _, _, isPassThrough, templateRefName, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 						Expect(template).ToNot(BeNil())
 						Expect(isPassThrough).To(BeFalse())
+						Expect(templateRefName).To(Equal("image-template-1"))
 
 						Expect(err).To(HaveOccurred())
 						Expect(err.Error()).To(ContainSubstring("bad object"))
@@ -345,7 +349,7 @@ var _ = Describe("Resource", func() {
 			})
 
 			It("returns GetTemplateError", func() {
-				template, _, _, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+				template, _, _, isPassThrough, _, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 				Expect(err).To(HaveOccurred())
 				Expect(template).To(BeNil())
 				Expect(isPassThrough).To(BeFalse())
@@ -372,10 +376,11 @@ var _ = Describe("Resource", func() {
 			})
 
 			It("returns a helpful error", func() {
-				template, _, _, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+				template, _, _, isPassThrough, templateRefName, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 
 				Expect(template).To(BeNil())
 				Expect(isPassThrough).To(BeFalse())
+				Expect(templateRefName).To(Equal("image-template-1"))
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to get cluster template [{Kind:ClusterImageTemplate Name:image-template-1}]: resource does not match a known template"))
@@ -404,9 +409,10 @@ var _ = Describe("Resource", func() {
 			})
 
 			It("returns StampError", func() {
-				template, _, _, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+				template, _, _, isPassThrough, templateRefName, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 				Expect(template).ToNot(BeNil())
 				Expect(isPassThrough).To(BeFalse())
+				Expect(templateRefName).To(Equal("image-template-1"))
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("unable to stamp object for resource [resource-1]"))
@@ -469,9 +475,10 @@ var _ = Describe("Resource", func() {
 			})
 
 			It("returns RetrieveOutputError", func() {
-				template, _, _, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+				template, _, _, isPassThrough, templateRefName, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 				Expect(template).ToNot(BeNil())
 				Expect(isPassThrough).To(BeFalse())
+				Expect(templateRefName).To(Equal("image-template-1"))
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("jsonpath returned empty list: data.does-not-exist"))
@@ -532,9 +539,10 @@ var _ = Describe("Resource", func() {
 				fakeOwnerRepo.EnsureMutableObjectExistsOnClusterReturns(errors.New("bad object"))
 			})
 			It("returns ApplyStampedObjectError", func() {
-				template, _, _, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+				template, _, _, isPassThrough, templateRefName, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 				Expect(template).ToNot(BeNil())
 				Expect(isPassThrough).To(BeFalse())
+				Expect(templateRefName).To(Equal("image-template-1"))
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("bad object"))
@@ -583,9 +591,10 @@ var _ = Describe("Resource", func() {
 			})
 
 			It("returns StampError", func() {
-				template, _, _, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+				template, _, _, isPassThrough, templateRefName, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 				Expect(template).ToNot(BeNil())
 				Expect(isPassThrough).To(BeFalse())
+				Expect(templateRefName).To(Equal("image-template-1"))
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("cannot set namespace in resource template"))
@@ -669,7 +678,7 @@ var _ = Describe("Resource", func() {
 				})
 
 				It("returns the input as an output", func() {
-					template, stamped, output, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+					template, stamped, output, isPassThrough, _, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 					Expect(template).To(BeNil())
 					Expect(stamped).To(BeNil())
 					Expect(isPassThrough).To(BeTrue())
@@ -679,7 +688,7 @@ var _ = Describe("Resource", func() {
 				})
 
 				It("does not call to the repo", func() {
-					_, _, _, _, _ = r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+					_, _, _, _, _, _ = r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 					Expect(fakeSystemRepo.GetTemplateCallCount()).To(Equal(0))
 					Expect(fakeOwnerRepo.EnsureMutableObjectExistsOnClusterCallCount()).To(Equal(0))
 				})
@@ -690,7 +699,7 @@ var _ = Describe("Resource", func() {
 					})
 
 					It("returns an error", func() {
-						template, stamped, output, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+						template, stamped, output, isPassThrough, _, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 						Expect(template).To(BeNil())
 						Expect(stamped).To(BeNil())
 						Expect(output).To(BeNil())
@@ -707,7 +716,7 @@ var _ = Describe("Resource", func() {
 					})
 
 					It("returns an error", func() {
-						template, stamped, output, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+						template, stamped, output, isPassThrough, _, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 						Expect(template).To(BeNil())
 						Expect(stamped).To(BeNil())
 						Expect(output).To(BeNil())
@@ -784,10 +793,11 @@ var _ = Describe("Resource", func() {
 
 				When("one option matches", func() {
 					It("finds the correct template", func() {
-						template, _, _, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+						template, _, _, isPassThrough, templateRefName, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 						Expect(template).ToNot(BeNil())
 						Expect(isPassThrough).To(BeFalse())
 						Expect(err).NotTo(HaveOccurred())
+						Expect(templateRefName).To(Equal("template-chosen"))
 
 						_, name, kind := fakeSystemRepo.GetTemplateArgsForCall(0)
 						Expect(name).To(Equal("template-chosen"))
@@ -799,7 +809,7 @@ var _ = Describe("Resource", func() {
 					It("returns a TemplateOptionsMatchError", func() {
 						resource.TemplateOptions[0].Selector.MatchFields[0].Key = "spec.source.git.ref.branch"
 
-						template, _, _, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+						template, _, _, isPassThrough, _, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 						Expect(template).To(BeNil())
 						Expect(isPassThrough).To(BeFalse())
 
@@ -814,7 +824,7 @@ var _ = Describe("Resource", func() {
 						resource.TemplateOptions[0].Selector.MatchFields[0].Key = "spec.source.image"
 						resource.TemplateOptions[1].Selector.MatchFields[0].Key = "spec.source.subPath"
 
-						template, _, _, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+						template, _, _, isPassThrough, _, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 
 						Expect(template).To(BeNil())
 						Expect(isPassThrough).To(BeFalse())
@@ -828,9 +838,10 @@ var _ = Describe("Resource", func() {
 					It("does not error", func() {
 						resource.TemplateOptions[0].Selector.MatchFields[0].Key = `spec.env[?(@.name=="some-name")].bad`
 
-						template, _, _, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+						template, _, _, isPassThrough, templateRefName, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 						Expect(template).ToNot(BeNil())
 						Expect(isPassThrough).To(BeFalse())
+						Expect(templateRefName).To(Equal("template-chosen"))
 
 						Expect(err).NotTo(HaveOccurred())
 						_, name, kind := fakeSystemRepo.GetTemplateArgsForCall(0)
@@ -843,7 +854,7 @@ var _ = Describe("Resource", func() {
 					It("returns a ResolveTemplateOptionError", func() {
 						resource.TemplateOptions[0].Selector.MatchFields[0].Key = `spec.env[`
 
-						template, _, _, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+						template, _, _, isPassThrough, _, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 						Expect(template).To(BeNil())
 						Expect(isPassThrough).To(BeFalse())
 
@@ -861,16 +872,16 @@ var _ = Describe("Resource", func() {
 							Operator: "Exists",
 						})
 
-						template, _, _, isPassThrough, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+						template, _, _, isPassThrough, templateRefName, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
 						Expect(template).ToNot(BeNil())
 						Expect(isPassThrough).To(BeFalse())
+						Expect(templateRefName).To(Equal("template-chosen"))
 
 						Expect(err).NotTo(HaveOccurred())
 						_, name, kind := fakeSystemRepo.GetTemplateArgsForCall(0)
 						Expect(name).To(Equal("template-chosen"))
 						Expect(kind).To(Equal("ClusterImageTemplate"))
 					})
-
 				})
 			})
 		})

--- a/pkg/realizer/realizerfakes/fake_resource_realizer.go
+++ b/pkg/realizer/realizerfakes/fake_resource_realizer.go
@@ -12,7 +12,7 @@ import (
 )
 
 type FakeResourceRealizer struct {
-	DoStub        func(context.Context, realizer.OwnerResource, string, realizer.Outputs, meta.RESTMapper) (templates.Reader, *unstructured.Unstructured, *templates.Output, bool, error)
+	DoStub        func(context.Context, realizer.OwnerResource, string, realizer.Outputs, meta.RESTMapper) (templates.Reader, *unstructured.Unstructured, *templates.Output, bool, string, error)
 	doMutex       sync.RWMutex
 	doArgsForCall []struct {
 		arg1 context.Context
@@ -26,20 +26,22 @@ type FakeResourceRealizer struct {
 		result2 *unstructured.Unstructured
 		result3 *templates.Output
 		result4 bool
-		result5 error
+		result5 string
+		result6 error
 	}
 	doReturnsOnCall map[int]struct {
 		result1 templates.Reader
 		result2 *unstructured.Unstructured
 		result3 *templates.Output
 		result4 bool
-		result5 error
+		result5 string
+		result6 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeResourceRealizer) Do(arg1 context.Context, arg2 realizer.OwnerResource, arg3 string, arg4 realizer.Outputs, arg5 meta.RESTMapper) (templates.Reader, *unstructured.Unstructured, *templates.Output, bool, error) {
+func (fake *FakeResourceRealizer) Do(arg1 context.Context, arg2 realizer.OwnerResource, arg3 string, arg4 realizer.Outputs, arg5 meta.RESTMapper) (templates.Reader, *unstructured.Unstructured, *templates.Output, bool, string, error) {
 	fake.doMutex.Lock()
 	ret, specificReturn := fake.doReturnsOnCall[len(fake.doArgsForCall)]
 	fake.doArgsForCall = append(fake.doArgsForCall, struct {
@@ -57,9 +59,9 @@ func (fake *FakeResourceRealizer) Do(arg1 context.Context, arg2 realizer.OwnerRe
 		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3, ret.result4, ret.result5
+		return ret.result1, ret.result2, ret.result3, ret.result4, ret.result5, ret.result6
 	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4, fakeReturns.result5
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4, fakeReturns.result5, fakeReturns.result6
 }
 
 func (fake *FakeResourceRealizer) DoCallCount() int {
@@ -68,7 +70,7 @@ func (fake *FakeResourceRealizer) DoCallCount() int {
 	return len(fake.doArgsForCall)
 }
 
-func (fake *FakeResourceRealizer) DoCalls(stub func(context.Context, realizer.OwnerResource, string, realizer.Outputs, meta.RESTMapper) (templates.Reader, *unstructured.Unstructured, *templates.Output, bool, error)) {
+func (fake *FakeResourceRealizer) DoCalls(stub func(context.Context, realizer.OwnerResource, string, realizer.Outputs, meta.RESTMapper) (templates.Reader, *unstructured.Unstructured, *templates.Output, bool, string, error)) {
 	fake.doMutex.Lock()
 	defer fake.doMutex.Unlock()
 	fake.DoStub = stub
@@ -81,7 +83,7 @@ func (fake *FakeResourceRealizer) DoArgsForCall(i int) (context.Context, realize
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
-func (fake *FakeResourceRealizer) DoReturns(result1 templates.Reader, result2 *unstructured.Unstructured, result3 *templates.Output, result4 bool, result5 error) {
+func (fake *FakeResourceRealizer) DoReturns(result1 templates.Reader, result2 *unstructured.Unstructured, result3 *templates.Output, result4 bool, result5 string, result6 error) {
 	fake.doMutex.Lock()
 	defer fake.doMutex.Unlock()
 	fake.DoStub = nil
@@ -90,11 +92,12 @@ func (fake *FakeResourceRealizer) DoReturns(result1 templates.Reader, result2 *u
 		result2 *unstructured.Unstructured
 		result3 *templates.Output
 		result4 bool
-		result5 error
-	}{result1, result2, result3, result4, result5}
+		result5 string
+		result6 error
+	}{result1, result2, result3, result4, result5, result6}
 }
 
-func (fake *FakeResourceRealizer) DoReturnsOnCall(i int, result1 templates.Reader, result2 *unstructured.Unstructured, result3 *templates.Output, result4 bool, result5 error) {
+func (fake *FakeResourceRealizer) DoReturnsOnCall(i int, result1 templates.Reader, result2 *unstructured.Unstructured, result3 *templates.Output, result4 bool, result5 string, result6 error) {
 	fake.doMutex.Lock()
 	defer fake.doMutex.Unlock()
 	fake.DoStub = nil
@@ -104,7 +107,8 @@ func (fake *FakeResourceRealizer) DoReturnsOnCall(i int, result1 templates.Reade
 			result2 *unstructured.Unstructured
 			result3 *templates.Output
 			result4 bool
-			result5 error
+			result5 string
+			result6 error
 		})
 	}
 	fake.doReturnsOnCall[i] = struct {
@@ -112,8 +116,9 @@ func (fake *FakeResourceRealizer) DoReturnsOnCall(i int, result1 templates.Reade
 		result2 *unstructured.Unstructured
 		result3 *templates.Output
 		result4 bool
-		result5 error
-	}{result1, result2, result3, result4, result5}
+		result5 string
+		result6 error
+	}{result1, result2, result3, result4, result5, result6}
 }
 
 func (fake *FakeResourceRealizer) Invocations() map[string][][]interface{} {

--- a/tests/kuttl/supplychain/options/02-assert.yaml
+++ b/tests/kuttl/supplychain/options/02-assert.yaml
@@ -44,3 +44,8 @@ status:
   supplyChainRef:
     name: responsible-ops---options
     kind: ClusterSupplyChain
+  resources:
+    - templateRef:
+        apiVersion: carto.run/v1alpha1
+        kind: ClusterSourceTemplate
+        name: git-template---options

--- a/tests/kuttl/supplychain/workload-supply-chain-hardcoded-templates/02-assert.yaml
+++ b/tests/kuttl/supplychain/workload-supply-chain-hardcoded-templates/02-assert.yaml
@@ -105,6 +105,24 @@ status:
   supplyChainRef:
     name: responsible-ops---workload-supply-chain-hardcoded-templates
     kind: ClusterSupplyChain
+  resources:
+    - templateRef:
+        apiVersion: carto.run/v1alpha1
+        kind: ClusterSourceTemplate
+        name: git-template---workload-supply-chain-hardcoded-templates
+    - templateRef:
+        apiVersion: carto.run/v1alpha1
+        kind: ClusterImageTemplate
+        name: kpack-template---workload-supply-chain-hardcoded-templates
+    - templateRef:
+        apiVersion: carto.run/v1alpha1
+        kind: ClusterConfigTemplate
+        name: config-template---workload-supply-chain-hardcoded-templates
+    - templateRef:
+        apiVersion: carto.run/v1alpha1
+        kind: ClusterTemplate
+        name: sink-template---workload-supply-chain-hardcoded-templates
+
 
 ---
 


### PR DESCRIPTION
Previously, when using options, the the workload's .status.resources[any-resource-using-options].templateRef.name field was not populated

<!--
Thanks for submitting a pull request to Cartographer!

Also check the [PR guidelines] if you haven't already!
-->

[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Changes proposed by this PR

<!--
Add the story that is resolved or updated
`closes`/`fixes` or `updates` are valid here 
-->
closes #1095 

<!--
Summarize your changes. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->


## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Add CreatorName field in Workload spec

Example notes:

* Operators can label stamped objects with the Workload's creator
* Creators can be contacted when interdepartmental issues arise 

If there are no additional notes necessary you may remove this entire section.
-->
[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- ~[ ] Filled in the [Release Note](#Release-Note) section above~
- ~[ ] Modified the docs to match changes~
