### PR TITLE
Add labels to template context for workload & deliverable

### DIFF
--- a/pkg/realizer/component.go
+++ b/pkg/realizer/component.go
@@ -39,7 +39,7 @@ import (
 //go:generate go run -modfile ../../hack/tools/go.mod github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
 type ContextGenerator interface {
-	Generate(templateParams TemplateParams, resource OwnerResource, outputs OutputsGetter) map[string]interface{}
+	Generate(templateParams TemplateParams, resource OwnerResource, outputs OutputsGetter, labels templates.Labels) map[string]interface{}
 }
 
 type resourceRealizer struct {
@@ -145,7 +145,7 @@ func (r *resourceRealizer) Do(ctx context.Context, resource OwnerResource, bluep
 
 		labels := r.resourceLabeler(resource, template)
 
-		stamper := templates.StamperBuilder(r.owner, r.templatingContext.Generate(template, resource, outputs), labels)
+		stamper := templates.StamperBuilder(r.owner, r.templatingContext.Generate(template, resource, outputs, labels), labels)
 		stampedObject, err = stamper.Stamp(ctx, template.GetResourceTemplate())
 		if err != nil {
 			log.Error(err, "failed to stamp resource")

--- a/pkg/realizer/context.go
+++ b/pkg/realizer/context.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/cartographer/pkg/apis/v1alpha1"
+	"github.com/vmware-tanzu/cartographer/pkg/templates"
 )
 
 // Todo: Pass an interface for owner and ownerParams that supports getParams and getObject
@@ -36,7 +37,7 @@ type contextGenerator struct {
 }
 
 // Generate builds a context based on the template, owner and resource
-func (c contextGenerator) Generate(templateParams TemplateParams, resource OwnerResource, outputs OutputsGetter) map[string]interface{} {
+func (c contextGenerator) Generate(templateParams TemplateParams, resource OwnerResource, outputs OutputsGetter, labels templates.Labels) map[string]interface{} {
 	inputGenerator := NewInputGenerator(resource, outputs)
 	merger := NewParamMerger(resource.Params, c.blueprintParams, c.ownerParams)
 
@@ -51,6 +52,7 @@ func (c contextGenerator) Generate(templateParams TemplateParams, resource Owner
 		"images":      images,
 		"configs":     configs,
 		"deployment":  inputGenerator.GetDeployment(),
+		"labels":      labels,
 	}
 
 	if len(sources) == 1 {

--- a/tests/kuttl/delivery/labels-in-context/00-service-account.yaml
+++ b/tests/kuttl/delivery/labels-in-context/00-service-account.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-service-account
+secrets:
+  - name: my-service-account-secret
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-service-account-secret
+  annotations:
+    kubernetes.io/service-account.name: my-service-account
+data:
+  token: "ZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNklubFNWM1YxVDNSRldESnZVRE4wTUd0R1EzQmlVVlJOVWtkMFNGb3RYMGh2VUhKYU1FRnVOR0Y0WlRBaWZRLmV5SnBjM01pT2lKcmRXSmxjbTVsZEdWekwzTmxjblpwWTJWaFkyTnZkVzUwSWl3aWEzVmlaWEp1WlhSbGN5NXBieTl6WlhKMmFXTmxZV05qYjNWdWRDOXVZVzFsYzNCaFkyVWlPaUprWldaaGRXeDBJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpXTnlaWFF1Ym1GdFpTSTZJbTE1TFhOaExYUnZhMlZ1TFd4dVkzRndJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpYSjJhV05sTFdGalkyOTFiblF1Ym1GdFpTSTZJbTE1TFhOaElpd2lhM1ZpWlhKdVpYUmxjeTVwYnk5elpYSjJhV05sWVdOamIzVnVkQzl6WlhKMmFXTmxMV0ZqWTI5MWJuUXVkV2xrSWpvaU9HSXhNV1V3WldNdFlURTVOeTAwWVdNeUxXRmpORFF0T0RjelpHSmpOVE13TkdKbElpd2ljM1ZpSWpvaWMzbHpkR1Z0T25ObGNuWnBZMlZoWTJOdmRXNTBPbVJsWm1GMWJIUTZiWGt0YzJFaWZRLmplMzRsZ3hpTUtnd0QxUGFhY19UMUZNWHdXWENCZmhjcVhQMEE2VUV2T0F6ek9xWGhpUUdGN2poY3RSeFhmUVFJVEs0Q2tkVmZ0YW5SUjNPRUROTUxVMVBXNXVsV3htVTZTYkMzdmZKT3ozLVJPX3BOVkNmVW8tZURpblN1Wm53bjNzMjNjZU9KM3IzYk04cnBrMHZZZFgyRVlQRGItMnd4cjIzZ1RxUjVxZU5ULW11cS1qYktXVE8wYnRYVl9wVHNjTnFXUkZIVzJBVTVHYVBpbmNWVXg1bXExLXN0SFdOOGtjTG96OF96S2RnUnJGYV92clFjb3NWZzZCRW5MSEt2NW1fVEhaR3AybU8wYmtIV3J1Q2xEUDdLc0tMOFVaZWxvTDN4Y3dQa000VlBBb2V0bDl5MzlvUi1KbWh3RUlIcS1hX3BzaVh5WE9EQU44STcybEZpUSU="
+type: kubernetes.io/service-account-token

--- a/tests/kuttl/delivery/labels-in-context/00-template-using-label.yaml
+++ b/tests/kuttl/delivery/labels-in-context/00-template-using-label.yaml
@@ -1,0 +1,29 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: carto.run/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: config-template---deliverable-labels-in-context
+spec:
+  configPath: .data.extractedLabel
+  ytt: |
+    #@ load("@ytt:data", "data")
+
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: test-output---deliverable-labels-in-context
+    data:
+      extractedLabel: #@ data.values.labels['carto.run/deliverable-name']

--- a/tests/kuttl/delivery/labels-in-context/01-cluster-delivery.yaml
+++ b/tests/kuttl/delivery/labels-in-context/01-cluster-delivery.yaml
@@ -1,0 +1,39 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: carto.run/v1alpha1
+kind: ClusterSupplyChain
+metadata:
+  name: responsible-ops---deliverable-labels-in-context
+spec:
+  selector:
+    integration-test: "deliverable-labels-in-context"
+  resources:
+    - name: config
+      templateRef:
+        kind: ClusterTemplate
+        name: config-template---deliverable-labels-in-context
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterDelivery
+metadata:
+  name: responsible-ops---deliverable-labels-in-context
+spec:
+  selector:
+    integration-test: "deliverable-labels-in-context"
+  resources:
+    - name: config
+      templateRef:
+        kind: ClusterTemplate
+        name: config-template---deliverable-labels-in-context

--- a/tests/kuttl/delivery/labels-in-context/02-assert.yaml
+++ b/tests/kuttl/delivery/labels-in-context/02-assert.yaml
@@ -1,0 +1,20 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-output---deliverable-labels-in-context
+data:
+  extractedLabel: petclinic---deliverable-labels-in-context

--- a/tests/kuttl/delivery/labels-in-context/02-deliverable.yaml
+++ b/tests/kuttl/delivery/labels-in-context/02-deliverable.yaml
@@ -1,0 +1,31 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: carto.run/v1alpha1
+kind: Deliverable
+metadata:
+  name: petclinic---deliverable-labels-in-context
+  labels:
+    integration-test: "deliverable-labels-in-context"
+spec:
+  serviceAccountName: my-service-account
+  source:
+    git:
+      url: https://github.com/ekcasey/hello-world-ops
+      ref:
+        branch: prod
+  params:
+    - name: some
+      value: value

--- a/tests/kuttl/supplychain/labels-in-context/00-service-account.yaml
+++ b/tests/kuttl/supplychain/labels-in-context/00-service-account.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-service-account
+secrets:
+  - name: my-service-account-secret
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-service-account-secret
+  annotations:
+    kubernetes.io/service-account.name: my-service-account
+data:
+  token: "ZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNklubFNWM1YxVDNSRldESnZVRE4wTUd0R1EzQmlVVlJOVWtkMFNGb3RYMGh2VUhKYU1FRnVOR0Y0WlRBaWZRLmV5SnBjM01pT2lKcmRXSmxjbTVsZEdWekwzTmxjblpwWTJWaFkyTnZkVzUwSWl3aWEzVmlaWEp1WlhSbGN5NXBieTl6WlhKMmFXTmxZV05qYjNWdWRDOXVZVzFsYzNCaFkyVWlPaUprWldaaGRXeDBJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpXTnlaWFF1Ym1GdFpTSTZJbTE1TFhOaExYUnZhMlZ1TFd4dVkzRndJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpYSjJhV05sTFdGalkyOTFiblF1Ym1GdFpTSTZJbTE1TFhOaElpd2lhM1ZpWlhKdVpYUmxjeTVwYnk5elpYSjJhV05sWVdOamIzVnVkQzl6WlhKMmFXTmxMV0ZqWTI5MWJuUXVkV2xrSWpvaU9HSXhNV1V3WldNdFlURTVOeTAwWVdNeUxXRmpORFF0T0RjelpHSmpOVE13TkdKbElpd2ljM1ZpSWpvaWMzbHpkR1Z0T25ObGNuWnBZMlZoWTJOdmRXNTBPbVJsWm1GMWJIUTZiWGt0YzJFaWZRLmplMzRsZ3hpTUtnd0QxUGFhY19UMUZNWHdXWENCZmhjcVhQMEE2VUV2T0F6ek9xWGhpUUdGN2poY3RSeFhmUVFJVEs0Q2tkVmZ0YW5SUjNPRUROTUxVMVBXNXVsV3htVTZTYkMzdmZKT3ozLVJPX3BOVkNmVW8tZURpblN1Wm53bjNzMjNjZU9KM3IzYk04cnBrMHZZZFgyRVlQRGItMnd4cjIzZ1RxUjVxZU5ULW11cS1qYktXVE8wYnRYVl9wVHNjTnFXUkZIVzJBVTVHYVBpbmNWVXg1bXExLXN0SFdOOGtjTG96OF96S2RnUnJGYV92clFjb3NWZzZCRW5MSEt2NW1fVEhaR3AybU8wYmtIV3J1Q2xEUDdLc0tMOFVaZWxvTDN4Y3dQa000VlBBb2V0bDl5MzlvUi1KbWh3RUlIcS1hX3BzaVh5WE9EQU44STcybEZpUSU="
+type: kubernetes.io/service-account-token

--- a/tests/kuttl/supplychain/labels-in-context/00-template-using-label.yaml
+++ b/tests/kuttl/supplychain/labels-in-context/00-template-using-label.yaml
@@ -1,0 +1,29 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: carto.run/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: config-template---workload-labels-in-context
+spec:
+  configPath: .data.extractedLabel
+  ytt: |
+    #@ load("@ytt:data", "data")
+
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: test-output---workload-labels-in-context
+    data:
+      extractedLabel: #@ data.values.labels['carto.run/workload-name']

--- a/tests/kuttl/supplychain/labels-in-context/01-supply-chain.yaml
+++ b/tests/kuttl/supplychain/labels-in-context/01-supply-chain.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: carto.run/v1alpha1
+kind: ClusterSupplyChain
+metadata:
+  name: responsible-ops---workload-labels-in-context
+spec:
+  selector:
+    integration-test: "workload-labels-in-context"
+  resources:
+    - name: config
+      templateRef:
+        kind: ClusterTemplate
+        name: config-template---workload-labels-in-context

--- a/tests/kuttl/supplychain/labels-in-context/02-assert.yaml
+++ b/tests/kuttl/supplychain/labels-in-context/02-assert.yaml
@@ -1,0 +1,20 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-output---workload-labels-in-context
+data:
+  extractedLabel: petclinic---workload-labels-in-context

--- a/tests/kuttl/supplychain/labels-in-context/02-workload.yaml
+++ b/tests/kuttl/supplychain/labels-in-context/02-workload.yaml
@@ -1,0 +1,30 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  name: petclinic---workload-labels-in-context
+  labels:
+    integration-test: "workload-labels-in-context"
+spec:
+  serviceAccountName: my-service-account
+  source:
+    git:
+      url: https://github.com/spring-projects/spring-petclinic.git
+      ref:
+        branch: main
+  params:
+    - name: waciuma-com/quality
+      value: omicron


### PR DESCRIPTION
## Changes proposed by this PR

This change makes the [labels that Cartographer will apply](https://cartographer.sh/docs/v0.6.0/stamping/#labels) to a stamped object available in the templating context for Workloads and Deliverables. This is useful if you want make templates which render Cartographer objects which you wish to make inert for later use (by placing their content into a ConfigMap or Secret, for example) and still want to preserve Cartographer's labelling.

## Release Note
`labels` for the currently templated resource are now available in the templating context for Workloads and Deliverables.

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above
- [ ] Modified the docs to match changes
