### PR TITLE
fix: immutable resource status

### DIFF
--- a/pkg/apis/v1alpha1/conditions.go
+++ b/pkg/apis/v1alpha1/conditions.go
@@ -159,15 +159,15 @@ const (
 // -- RUNNABLE ConditionType - RunTemplateReady ConditionReasons
 
 const (
-	ReadyRunTemplateReason                            = "Ready"
-	NotFoundRunTemplateReason                         = "RunTemplateNotFound"
-	StampedObjectRejectedByAPIServerRunTemplateReason = "StampedObjectRejectedByAPIServer"
-	OutputPathNotSatisfiedRunTemplateReason           = "OutputPathNotSatisfied"
-	TemplateStampFailureRunTemplateReason             = "TemplateStampFailure"
-	FailedToListCreatedObjectsReason                  = "FailedToListCreatedObjects"
-	NoHealthyStampedObjectsFoundReason                = "NoHealthyStampedObjectsFound"
-	UnknownErrorReason                                = "UnknownError"
-	ClientBuilderErrorResourcesSubmittedReason        = "ClientBuilderError"
-	SucceededStampedObjectConditionReason             = "SucceededCondition"
-	UnknownStampedObjectConditionReason               = "Unknown"
+	ReadyRunTemplateReason                                    = "Ready"
+	NotFoundRunTemplateReason                                 = "RunTemplateNotFound"
+	StampedObjectRejectedByAPIServerRunTemplateReason         = "StampedObjectRejectedByAPIServer"
+	OutputPathNotSatisfiedRunTemplateReason                   = "OutputPathNotSatisfied"
+	TemplateStampFailureRunTemplateReason                     = "TemplateStampFailure"
+	FailedToListCreatedObjectsReason                          = "FailedToListCreatedObjects"
+	SetOfImmutableStampedObjectsIncludesNoHealthyObjectReason = "SetOfImmutableStampedObjectsIncludesNoHealthyObject"
+	UnknownErrorReason                                        = "UnknownError"
+	ClientBuilderErrorResourcesSubmittedReason                = "ClientBuilderError"
+	SucceededStampedObjectConditionReason                     = "SucceededCondition"
+	UnknownStampedObjectConditionReason                       = "Unknown"
 )

--- a/pkg/apis/v1alpha1/conditions.go
+++ b/pkg/apis/v1alpha1/conditions.go
@@ -165,6 +165,7 @@ const (
 	OutputPathNotSatisfiedRunTemplateReason           = "OutputPathNotSatisfied"
 	TemplateStampFailureRunTemplateReason             = "TemplateStampFailure"
 	FailedToListCreatedObjectsReason                  = "FailedToListCreatedObjects"
+	NoHealthyStampedObjectsFoundReason                = "NoHealthyStampedObjectsFound"
 	UnknownErrorReason                                = "UnknownError"
 	ClientBuilderErrorResourcesSubmittedReason        = "ClientBuilderError"
 	SucceededStampedObjectConditionReason             = "SucceededCondition"

--- a/pkg/conditions/owner_conditions.go
+++ b/pkg/conditions/owner_conditions.go
@@ -102,6 +102,15 @@ func BlueprintsFailedToListCreatedObjectsCondition(isOwner bool, err error) meta
 	}
 }
 
+func NoHealthyImmutableObjectsCondition(isOwner bool, err error) metav1.Condition {
+	return metav1.Condition{
+		Type:    getConditionType(isOwner),
+		Status:  metav1.ConditionFalse,
+		Reason:  v1alpha1.NoHealthyStampedObjectsFoundReason,
+		Message: err.Error(),
+	}
+}
+
 func UnknownResourceErrorCondition(isOwner bool, err error) metav1.Condition {
 	return metav1.Condition{
 		Type:    getConditionType(isOwner),

--- a/pkg/conditions/owner_conditions.go
+++ b/pkg/conditions/owner_conditions.go
@@ -106,7 +106,7 @@ func NoHealthyImmutableObjectsCondition(isOwner bool, err error) metav1.Conditio
 	return metav1.Condition{
 		Type:    getConditionType(isOwner),
 		Status:  metav1.ConditionFalse,
-		Reason:  v1alpha1.NoHealthyStampedObjectsFoundReason,
+		Reason:  v1alpha1.SetOfImmutableStampedObjectsIncludesNoHealthyObjectReason,
 		Message: err.Error(),
 	}
 }

--- a/pkg/conditions/workload_conditions.go
+++ b/pkg/conditions/workload_conditions.go
@@ -79,6 +79,8 @@ func AddConditionForResourceSubmittedWorkload(conditionManager *ConditionManager
 		(*conditionManager).AddPositive(TemplateRejectedByAPIServerCondition(isOwner, typedErr))
 	case cerrors.ListCreatedObjectsError:
 		(*conditionManager).AddPositive(BlueprintsFailedToListCreatedObjectsCondition(isOwner, typedErr))
+	case cerrors.NoHealthyImmutableObjectsError:
+		(*conditionManager).AddPositive(NoHealthyImmutableObjectsCondition(isOwner, typedErr))
 	case cerrors.RetrieveOutputError:
 		(*conditionManager).AddPositive(MissingValueAtPathCondition(isOwner, typedErr.StampedObject, typedErr.JsonPathExpression(), typedErr.GetQualifiedResource()))
 	case cerrors.ResolveTemplateOptionError:

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -124,13 +124,14 @@ func (e StampError) Error() string {
 }
 
 type RetrieveOutputError struct {
-	Err               error
-	ResourceName      string
-	StampedObject     *unstructured.Unstructured
-	BlueprintName     string
-	BlueprintType     string
-	QualifiedResource string
-	PassThroughInput  string
+	Err                  error
+	ResourceName         string
+	StampedObject        *unstructured.Unstructured
+	BlueprintName        string
+	BlueprintType        string
+	QualifiedResource    string
+	PassThroughInput     string
+	IsLifecycleImmutable bool
 }
 
 func (e RetrieveOutputError) Error() string {
@@ -141,6 +142,15 @@ func (e RetrieveOutputError) Error() string {
 			e.BlueprintType,
 			e.BlueprintName,
 			e.Err).Error()
+	}
+
+	if e.IsLifecycleImmutable && e.QualifiedResource == "" {
+		return fmt.Errorf("unable to retrieve outputs for resource [%s] in %s [%s]: %w",
+			e.ResourceName,
+			e.BlueprintType,
+			e.BlueprintName,
+			e.Err,
+		).Error()
 	}
 
 	if e.JsonPathExpression() == NoJsonpathContext {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -124,14 +124,13 @@ func (e StampError) Error() string {
 }
 
 type RetrieveOutputError struct {
-	Err                  error
-	ResourceName         string
-	StampedObject        *unstructured.Unstructured
-	BlueprintName        string
-	BlueprintType        string
-	QualifiedResource    string
-	PassThroughInput     string
-	IsLifecycleImmutable bool
+	Err               error
+	ResourceName      string
+	StampedObject     *unstructured.Unstructured
+	BlueprintName     string
+	BlueprintType     string
+	QualifiedResource string
+	PassThroughInput  string
 }
 
 func (e RetrieveOutputError) Error() string {
@@ -142,15 +141,6 @@ func (e RetrieveOutputError) Error() string {
 			e.BlueprintType,
 			e.BlueprintName,
 			e.Err).Error()
-	}
-
-	if e.IsLifecycleImmutable && e.QualifiedResource == "" {
-		return fmt.Errorf("unable to retrieve outputs for resource [%s] in %s [%s]: %w",
-			e.ResourceName,
-			e.BlueprintType,
-			e.BlueprintName,
-			e.Err,
-		).Error()
 	}
 
 	if e.JsonPathExpression() == NoJsonpathContext {
@@ -194,6 +184,22 @@ func (e RetrieveOutputError) GetResourceName() string {
 
 func (e RetrieveOutputError) GetQualifiedResource() string {
 	return e.QualifiedResource
+}
+
+type NoHealthyImmutableObjectsError struct {
+	Err           error
+	ResourceName  string
+	BlueprintName string
+	BlueprintType string
+}
+
+func (e NoHealthyImmutableObjectsError) Error() string {
+	return fmt.Errorf("unable to retrieve outputs for resource [%s] in %s [%s]: %w",
+		e.ResourceName,
+		e.BlueprintType,
+		e.BlueprintName,
+		e.Err,
+	).Error()
 }
 
 func WrapUnhandledError(err error) error {

--- a/pkg/realizer/component.go
+++ b/pkg/realizer/component.go
@@ -188,9 +188,6 @@ func (r *resourceRealizer) doImmutable(ctx context.Context, resource OwnerResour
 	}
 
 	healthRule := template.GetHealthRule()
-	if healthRule == nil && *template.GetLifecycle() == templates.Tekton {
-		healthRule = &v1alpha1.HealthRule{SingleConditionType: "Succeeded"}
-	}
 
 	var examinedObjects []*stamp.ExaminedObject
 

--- a/pkg/realizer/component.go
+++ b/pkg/realizer/component.go
@@ -211,15 +211,11 @@ func (r *resourceRealizer) doImmutable(ctx context.Context, resource OwnerResour
 			log.V(logger.DEBUG).Info("failed to retrieve output from any object", "considered", obj)
 		}
 
-		return template, stampedObject, nil, passThrough, templateName, errors.RetrieveOutputError{
-			Err:                  fmt.Errorf("failed to find any healthy object in set of stamped objects"),
-			ResourceName:         resource.Name,
-			StampedObject:        stampedObject,
-			BlueprintName:        blueprintName,
-			BlueprintType:        errors.SupplyChain,
-			QualifiedResource:    "",
-			PassThroughInput:     templateOption.PassThrough,
-			IsLifecycleImmutable: true,
+		return template, stampedObject, nil, passThrough, templateName, errors.NoHealthyImmutableObjectsError{
+			Err:           fmt.Errorf("failed to find any healthy object in the set of stamped objects"),
+			ResourceName:  resource.Name,
+			BlueprintName: blueprintName,
+			BlueprintType: errors.SupplyChain,
 		}
 	}
 
@@ -233,14 +229,13 @@ func (r *resourceRealizer) doImmutable(ctx context.Context, resource OwnerResour
 		}
 
 		return template, stampedObject, nil, passThrough, templateName, errors.RetrieveOutputError{
-			Err:                  err,
-			ResourceName:         resource.Name,
-			StampedObject:        stampedObject,
-			BlueprintName:        blueprintName,
-			BlueprintType:        errors.SupplyChain,
-			QualifiedResource:    qualifiedResource,
-			PassThroughInput:     templateOption.PassThrough,
-			IsLifecycleImmutable: true,
+			Err:               err,
+			ResourceName:      resource.Name,
+			StampedObject:     stampedObject,
+			BlueprintName:     blueprintName,
+			BlueprintType:     errors.SupplyChain,
+			QualifiedResource: qualifiedResource,
+			PassThroughInput:  templateOption.PassThrough,
 		}
 	}
 

--- a/pkg/realizer/component.go
+++ b/pkg/realizer/component.go
@@ -212,7 +212,7 @@ func (r *resourceRealizer) doImmutable(ctx context.Context, resource OwnerResour
 		}
 
 		return template, stampedObject, nil, passThrough, templateName, errors.NoHealthyImmutableObjectsError{
-			Err:           fmt.Errorf("failed to find any healthy object in the set of stamped objects"),
+			Err:           fmt.Errorf("failed to find any healthy object in the set of immutable stamped objects"),
 			ResourceName:  resource.Name,
 			BlueprintName: blueprintName,
 			BlueprintType: errors.SupplyChain,

--- a/pkg/realizer/component.go
+++ b/pkg/realizer/component.go
@@ -214,8 +214,16 @@ func (r *resourceRealizer) doImmutable(ctx context.Context, resource OwnerResour
 			log.V(logger.DEBUG).Info("failed to retrieve output from any object", "considered", obj)
 		}
 
-		return template, stampedObject, nil, passThrough, templateName, nil
-
+		return template, stampedObject, nil, passThrough, templateName, errors.RetrieveOutputError{
+			Err:                  fmt.Errorf("failed to find any healthy object in set of stamped objects"),
+			ResourceName:         resource.Name,
+			StampedObject:        stampedObject,
+			BlueprintName:        blueprintName,
+			BlueprintType:        errors.SupplyChain,
+			QualifiedResource:    "",
+			PassThroughInput:     templateOption.PassThrough,
+			IsLifecycleImmutable: true,
+		}
 	}
 
 	output, err = stampReader.Output(latestSuccessfulObject)
@@ -228,13 +236,14 @@ func (r *resourceRealizer) doImmutable(ctx context.Context, resource OwnerResour
 		}
 
 		return template, stampedObject, nil, passThrough, templateName, errors.RetrieveOutputError{
-			Err:               err,
-			ResourceName:      resource.Name,
-			StampedObject:     stampedObject,
-			BlueprintName:     blueprintName,
-			BlueprintType:     errors.SupplyChain,
-			QualifiedResource: qualifiedResource,
-			PassThroughInput:  templateOption.PassThrough,
+			Err:                  err,
+			ResourceName:         resource.Name,
+			StampedObject:        stampedObject,
+			BlueprintName:        blueprintName,
+			BlueprintType:        errors.SupplyChain,
+			QualifiedResource:    qualifiedResource,
+			PassThroughInput:     templateOption.PassThrough,
+			IsLifecycleImmutable: true,
 		}
 	}
 

--- a/pkg/realizer/component.go
+++ b/pkg/realizer/component.go
@@ -211,6 +211,7 @@ func (r *resourceRealizer) Do(ctx context.Context, resource OwnerResource, bluep
 				for _, obj := range allRunnableStampedObjects {
 					log.V(logger.DEBUG).Info("failed to retrieve output from any object", "considered", obj)
 				}
+				// TODO: throw a custom error here
 			}
 
 			output, err = stampReader.Output(latestSuccessfulObject)

--- a/pkg/realizer/component_test.go
+++ b/pkg/realizer/component_test.go
@@ -309,7 +309,7 @@ var _ = Describe("Resource", func() {
 								Expect(metadataValues["labels"]).To(Equal(map[string]interface{}{"expected-labels-from-labeler-placeholder": "labeler"}))
 
 								Expect(err).To(HaveOccurred())
-								Expect(err.Error()).To(ContainSubstring("unable to retrieve outputs for resource [resource-1] in supply chain [supply-chain-name]: failed to find any healthy object in the set of stamped objects"))
+								Expect(err.Error()).To(ContainSubstring("unable to retrieve outputs for resource [resource-1] in supply chain [supply-chain-name]: failed to find any healthy object in the set of immutable stamped objects"))
 								Expect(reflect.TypeOf(err).String()).To(Equal("errors.NoHealthyImmutableObjectsError"))
 							})
 						})

--- a/pkg/realizer/component_test.go
+++ b/pkg/realizer/component_test.go
@@ -310,7 +310,7 @@ var _ = Describe("Resource", func() {
 
 								Expect(err).To(HaveOccurred())
 								Expect(err.Error()).To(ContainSubstring("unable to retrieve outputs for resource [resource-1] in supply chain [supply-chain-name]: failed to find any healthy object in the set of stamped objects"))
-								Expect(reflect.TypeOf(err).String()).To(Equal("errors.RetrieveOutputError"))
+								Expect(reflect.TypeOf(err).String()).To(Equal("errors.NoHealthyImmutableObjectsError"))
 							})
 						})
 

--- a/pkg/realizer/component_test.go
+++ b/pkg/realizer/component_test.go
@@ -309,7 +309,7 @@ var _ = Describe("Resource", func() {
 								Expect(metadataValues["labels"]).To(Equal(map[string]interface{}{"expected-labels-from-labeler-placeholder": "labeler"}))
 
 								Expect(err).To(HaveOccurred())
-								Expect(err.Error()).To(ContainSubstring("unable to retrieve outputs for resource [resource-1] in supply chain [supply-chain-name]: failed to find any healthy object in set of stamped objects"))
+								Expect(err.Error()).To(ContainSubstring("unable to retrieve outputs for resource [resource-1] in supply chain [supply-chain-name]: failed to find any healthy object in the set of stamped objects"))
 								Expect(reflect.TypeOf(err).String()).To(Equal("errors.RetrieveOutputError"))
 							})
 						})

--- a/pkg/templates/cluster_config_template.go
+++ b/pkg/templates/cluster_config_template.go
@@ -50,6 +50,10 @@ func (t *clusterConfigTemplate) GetDefaultParams() v1alpha1.TemplateParams {
 }
 
 func (t *clusterConfigTemplate) GetHealthRule() *v1alpha1.HealthRule {
+	if t.template.Spec.HealthRule == nil && t.template.Spec.Lifecycle == "tekton" {
+		return &v1alpha1.HealthRule{SingleConditionType: "Succeeded"}
+	}
+
 	return t.template.Spec.HealthRule
 }
 

--- a/pkg/templates/cluster_deployment_template.go
+++ b/pkg/templates/cluster_deployment_template.go
@@ -50,6 +50,10 @@ func (t *clusterDeploymentTemplate) GetDefaultParams() v1alpha1.TemplateParams {
 }
 
 func (t *clusterDeploymentTemplate) GetHealthRule() *v1alpha1.HealthRule {
+	if t.template.Spec.HealthRule == nil && t.template.Spec.Lifecycle == "tekton" {
+		return &v1alpha1.HealthRule{SingleConditionType: "Succeeded"}
+	}
+
 	return t.template.Spec.HealthRule
 }
 

--- a/pkg/templates/cluster_image_template.go
+++ b/pkg/templates/cluster_image_template.go
@@ -52,6 +52,10 @@ func (t *clusterImageTemplate) GetDefaultParams() v1alpha1.TemplateParams {
 }
 
 func (t *clusterImageTemplate) GetHealthRule() *v1alpha1.HealthRule {
+	if t.template.Spec.HealthRule == nil && t.template.Spec.Lifecycle == "tekton" {
+		return &v1alpha1.HealthRule{SingleConditionType: "Succeeded"}
+	}
+
 	return t.template.Spec.HealthRule
 }
 

--- a/pkg/templates/cluster_source_template.go
+++ b/pkg/templates/cluster_source_template.go
@@ -50,6 +50,10 @@ func (t *clusterSourceTemplate) GetDefaultParams() v1alpha1.TemplateParams {
 }
 
 func (t *clusterSourceTemplate) GetHealthRule() *v1alpha1.HealthRule {
+	if t.template.Spec.HealthRule == nil && t.template.Spec.Lifecycle == "tekton" {
+		return &v1alpha1.HealthRule{SingleConditionType: "Succeeded"}
+	}
+
 	return t.template.Spec.HealthRule
 }
 

--- a/pkg/templates/cluster_template.go
+++ b/pkg/templates/cluster_template.go
@@ -50,6 +50,10 @@ func (t *clusterTemplate) GetDefaultParams() v1alpha1.TemplateParams {
 }
 
 func (t *clusterTemplate) GetHealthRule() *v1alpha1.HealthRule {
+	if t.template.Spec.HealthRule == nil && t.template.Spec.Lifecycle == "tekton" {
+		return &v1alpha1.HealthRule{SingleConditionType: "Succeeded"}
+	}
+
 	return t.template.Spec.HealthRule
 }
 

--- a/tests/integration/supplychain/workload_reconciler_test.go
+++ b/tests/integration/supplychain/workload_reconciler_test.go
@@ -691,8 +691,8 @@ var _ = Describe("WorkloadReconciler", func() {
 						}).Should(MatchAllElements(getConditionOfType, Elements{
 							"ResourceSubmitted": MatchFields(IgnoreExtras, Fields{
 								"Status":  Equal(metav1.ConditionFalse),
-								"Reason":  Equal(v1alpha1.NoHealthyStampedObjectsFoundReason),
-								"Message": ContainSubstring("unable to retrieve outputs for resource [my-first-resource] in supply chain [my-supply-chain]: failed to find any healthy object in the set of stamped objects"),
+								"Reason":  Equal(v1alpha1.SetOfImmutableStampedObjectsIncludesNoHealthyObjectReason),
+								"Message": ContainSubstring("unable to retrieve outputs for resource [my-first-resource] in supply chain [my-supply-chain]: failed to find any healthy object in the set of immutable stamped objects"),
 							}),
 							"Healthy": MatchFields(IgnoreExtras, Fields{
 								"Status":  Equal(metav1.ConditionUnknown),
@@ -701,7 +701,7 @@ var _ = Describe("WorkloadReconciler", func() {
 							}),
 							"Ready": MatchFields(IgnoreExtras, Fields{
 								"Status": Equal(metav1.ConditionFalse),
-								"Reason": Equal(v1alpha1.NoHealthyStampedObjectsFoundReason),
+								"Reason": Equal(v1alpha1.SetOfImmutableStampedObjectsIncludesNoHealthyObjectReason),
 							}),
 						}))
 
@@ -715,7 +715,7 @@ var _ = Describe("WorkloadReconciler", func() {
 							}),
 							"ResourcesSubmitted": MatchFields(IgnoreExtras, Fields{
 								"Status": Equal(metav1.ConditionFalse),
-								"Reason": Equal(v1alpha1.NoHealthyStampedObjectsFoundReason),
+								"Reason": Equal(v1alpha1.SetOfImmutableStampedObjectsIncludesNoHealthyObjectReason),
 							}),
 							"ResourcesHealthy": MatchFields(IgnoreExtras, Fields{
 								"Status": Equal(metav1.ConditionUnknown),
@@ -944,8 +944,8 @@ var _ = Describe("WorkloadReconciler", func() {
 						}).Should(MatchAllElements(getConditionOfType, Elements{
 							"ResourceSubmitted": MatchFields(IgnoreExtras, Fields{
 								"Status":  Equal(metav1.ConditionFalse),
-								"Reason":  Equal(v1alpha1.NoHealthyStampedObjectsFoundReason),
-								"Message": ContainSubstring("unable to retrieve outputs for resource [my-first-resource] in supply chain [my-supply-chain]: failed to find any healthy object in the set of stamped objects"),
+								"Reason":  Equal(v1alpha1.SetOfImmutableStampedObjectsIncludesNoHealthyObjectReason),
+								"Message": ContainSubstring("unable to retrieve outputs for resource [my-first-resource] in supply chain [my-supply-chain]: failed to find any healthy object in the set of immutable stamped objects"),
 							}),
 							"Healthy": MatchFields(IgnoreExtras, Fields{
 								"Status":  Equal(metav1.ConditionUnknown),
@@ -954,7 +954,7 @@ var _ = Describe("WorkloadReconciler", func() {
 							}),
 							"Ready": MatchFields(IgnoreExtras, Fields{
 								"Status": Equal(metav1.ConditionFalse),
-								"Reason": Equal(v1alpha1.NoHealthyStampedObjectsFoundReason),
+								"Reason": Equal(v1alpha1.SetOfImmutableStampedObjectsIncludesNoHealthyObjectReason),
 							}),
 						}))
 
@@ -968,7 +968,7 @@ var _ = Describe("WorkloadReconciler", func() {
 							}),
 							"ResourcesSubmitted": MatchFields(IgnoreExtras, Fields{
 								"Status": Equal(metav1.ConditionFalse),
-								"Reason": Equal(v1alpha1.NoHealthyStampedObjectsFoundReason),
+								"Reason": Equal(v1alpha1.SetOfImmutableStampedObjectsIncludesNoHealthyObjectReason),
 							}),
 							"ResourcesHealthy": MatchFields(IgnoreExtras, Fields{
 								"Status": Equal(metav1.ConditionUnknown),

--- a/tests/integration/supplychain/workload_reconciler_test.go
+++ b/tests/integration/supplychain/workload_reconciler_test.go
@@ -799,7 +799,7 @@ var _ = Describe("WorkloadReconciler", func() {
 						))
 					})
 
-					It("prevents reading fields of the stamped object", func() {
+					FIt("prevents reading fields of the stamped object", func() {
 						getConditionOfType := func(element interface{}) string {
 							return element.(metav1.Condition).Type
 						}
@@ -826,6 +826,7 @@ var _ = Describe("WorkloadReconciler", func() {
 						err := c.Get(ctx, client.ObjectKey{Name: "workload-joe", Namespace: testNS}, workload)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(workload.Status.Resources[0].Outputs).To(HaveLen(0))
+						itResultsInAHealthyWorkload()
 					})
 				})
 			})

--- a/tests/integration/supplychain/workload_reconciler_test.go
+++ b/tests/integration/supplychain/workload_reconciler_test.go
@@ -799,7 +799,7 @@ var _ = Describe("WorkloadReconciler", func() {
 						))
 					})
 
-					FIt("prevents reading fields of the stamped object", func() {
+					It("prevents reading fields of the stamped object", func() {
 						getConditionOfType := func(element interface{}) string {
 							return element.(metav1.Condition).Type
 						}
@@ -826,7 +826,6 @@ var _ = Describe("WorkloadReconciler", func() {
 						err := c.Get(ctx, client.ObjectKey{Name: "workload-joe", Namespace: testNS}, workload)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(workload.Status.Resources[0].Outputs).To(HaveLen(0))
-						itResultsInAHealthyWorkload()
 					})
 				})
 			})

--- a/tests/integration/supplychain/workload_reconciler_test.go
+++ b/tests/integration/supplychain/workload_reconciler_test.go
@@ -653,23 +653,7 @@ var _ = Describe("WorkloadReconciler", func() {
 					It("stamps the templated object once", func() {
 						itStampsTheTemplatedObjectOnce()
 					})
-					It("results in an unhealthy workload", func() {
-						Eventually(func() []metav1.Condition {
-							obj := &v1alpha1.Workload{}
-							err := c.Get(ctx, client.ObjectKey{Name: "workload-joe", Namespace: testNS}, obj)
-							Expect(err).NotTo(HaveOccurred())
-
-							return obj.Status.Conditions
-						}).Should(ContainElements(
-							MatchFields(IgnoreExtras, Fields{
-								"Type":   Equal("ResourcesHealthy"),
-								"Reason": Equal("HealthyConditionRule"),
-								"Status": Equal(metav1.ConditionUnknown),
-							}),
-						))
-					})
-
-					It("prevents reading fields of the stamped object", func() {
+					It("results in proper status", func() {
 						getConditionOfType := func(element interface{}) string {
 							return element.(metav1.Condition).Type
 						}
@@ -683,18 +667,45 @@ var _ = Describe("WorkloadReconciler", func() {
 								return []metav1.Condition{}
 							}
 
-							return workload.Status.Resources[1].Conditions
-						}).Should(MatchElements(getConditionOfType, IgnoreExtras, Elements{
+							return workload.Status.Resources[0].Conditions
+						}).Should(MatchAllElements(getConditionOfType, Elements{
 							"ResourceSubmitted": MatchFields(IgnoreExtras, Fields{
 								"Status":  Equal(metav1.ConditionFalse),
-								"Reason":  Equal("TemplateStampFailure"),
-								"Message": ContainSubstring("failed to recursively evaluate template: failed to interpolate template at path [data.foo]: evaluate tag $(config)$: jsonpath returned empty list: config"),
+								"Reason":  Equal(v1alpha1.NoHealthyStampedObjectsFoundReason),
+								"Message": ContainSubstring("unable to retrieve outputs for resource [my-first-resource] in supply chain [my-supply-chain]: failed to find any healthy object in the set of stamped objects"),
+							}),
+							"Healthy": MatchFields(IgnoreExtras, Fields{
+								"Status":  Equal(metav1.ConditionUnknown),
+								"Reason":  Equal("ReadyCondition"),
+								"Message": ContainSubstring("condition with type [Ready] not found on resource status"),
+							}),
+							"Ready": MatchFields(IgnoreExtras, Fields{
+								"Status": Equal(metav1.ConditionFalse),
+								"Reason": Equal(v1alpha1.NoHealthyStampedObjectsFoundReason),
 							}),
 						}))
 
 						workload := &v1alpha1.Workload{}
 						err := c.Get(ctx, client.ObjectKey{Name: "workload-joe", Namespace: testNS}, workload)
 						Expect(err).NotTo(HaveOccurred())
+
+						Expect(workload.Status.Conditions).To(MatchAllElements(getConditionOfType, Elements{
+							"SupplyChainReady": MatchFields(IgnoreExtras, Fields{
+								"Status": Equal(metav1.ConditionTrue),
+							}),
+							"ResourcesSubmitted": MatchFields(IgnoreExtras, Fields{
+								"Status": Equal(metav1.ConditionFalse),
+								"Reason": Equal(v1alpha1.NoHealthyStampedObjectsFoundReason),
+							}),
+							"ResourcesHealthy": MatchFields(IgnoreExtras, Fields{
+								"Status": Equal(metav1.ConditionUnknown),
+								"Reason": Equal("HealthyConditionRule"),
+							}),
+							"Ready": MatchFields(IgnoreExtras, Fields{
+								"Status": Equal(metav1.ConditionFalse),
+							}),
+						}))
+
 						Expect(workload.Status.Resources[0].Outputs).To(HaveLen(0))
 					})
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Cartographer!

Also check the [PR guidelines] if you haven't already!
-->

[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Changes proposed by this PR

<!--
Add the story that is resolved or updated
`closes`/`fixes` or `updates` are valid here 
-->
Resolves #1120

Also resolves an issue where `lifecycle:tekton` resources would remain in a healthy state, even if the most recent object was in an unknown or unhealthy state.

<!--
Summarize your changes. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->


## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Add CreatorName field in Workload spec

Example notes:

* Operators can label stamped objects with the Workload's creator
* Creators can be contacted when interdepartmental issues arise 

If there are no additional notes necessary you may remove this entire section.
-->
[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [ ] Removed non-atomic or `wip` commits
- ~[ ] Filled in the [Release Note](#Release-Note) section above~
- ~[ ] Modified the docs to match changes~
