### PR TITLE
Backport labels in template context

### DIFF
--- a/pkg/realizer/component.go
+++ b/pkg/realizer/component.go
@@ -130,6 +130,7 @@ func (r *resourceRealizer) Do(ctx context.Context, resource OwnerResource, bluep
 		"images":      inputs.Images,
 		"deployment":  inputs.Deployment,
 		"configs":     inputs.Configs,
+		"labels":      labels,
 	}
 
 	if inputs.OnlyConfig() != nil {

--- a/tests/kuttl/delivery/labels-in-context/00-service-account.yaml
+++ b/tests/kuttl/delivery/labels-in-context/00-service-account.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-service-account
+secrets:
+  - name: my-service-account-secret
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-service-account-secret
+  annotations:
+    kubernetes.io/service-account.name: my-service-account
+data:
+  token: "ZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNklubFNWM1YxVDNSRldESnZVRE4wTUd0R1EzQmlVVlJOVWtkMFNGb3RYMGh2VUhKYU1FRnVOR0Y0WlRBaWZRLmV5SnBjM01pT2lKcmRXSmxjbTVsZEdWekwzTmxjblpwWTJWaFkyTnZkVzUwSWl3aWEzVmlaWEp1WlhSbGN5NXBieTl6WlhKMmFXTmxZV05qYjNWdWRDOXVZVzFsYzNCaFkyVWlPaUprWldaaGRXeDBJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpXTnlaWFF1Ym1GdFpTSTZJbTE1TFhOaExYUnZhMlZ1TFd4dVkzRndJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpYSjJhV05sTFdGalkyOTFiblF1Ym1GdFpTSTZJbTE1TFhOaElpd2lhM1ZpWlhKdVpYUmxjeTVwYnk5elpYSjJhV05sWVdOamIzVnVkQzl6WlhKMmFXTmxMV0ZqWTI5MWJuUXVkV2xrSWpvaU9HSXhNV1V3WldNdFlURTVOeTAwWVdNeUxXRmpORFF0T0RjelpHSmpOVE13TkdKbElpd2ljM1ZpSWpvaWMzbHpkR1Z0T25ObGNuWnBZMlZoWTJOdmRXNTBPbVJsWm1GMWJIUTZiWGt0YzJFaWZRLmplMzRsZ3hpTUtnd0QxUGFhY19UMUZNWHdXWENCZmhjcVhQMEE2VUV2T0F6ek9xWGhpUUdGN2poY3RSeFhmUVFJVEs0Q2tkVmZ0YW5SUjNPRUROTUxVMVBXNXVsV3htVTZTYkMzdmZKT3ozLVJPX3BOVkNmVW8tZURpblN1Wm53bjNzMjNjZU9KM3IzYk04cnBrMHZZZFgyRVlQRGItMnd4cjIzZ1RxUjVxZU5ULW11cS1qYktXVE8wYnRYVl9wVHNjTnFXUkZIVzJBVTVHYVBpbmNWVXg1bXExLXN0SFdOOGtjTG96OF96S2RnUnJGYV92clFjb3NWZzZCRW5MSEt2NW1fVEhaR3AybU8wYmtIV3J1Q2xEUDdLc0tMOFVaZWxvTDN4Y3dQa000VlBBb2V0bDl5MzlvUi1KbWh3RUlIcS1hX3BzaVh5WE9EQU44STcybEZpUSU="
+type: kubernetes.io/service-account-token

--- a/tests/kuttl/delivery/labels-in-context/00-template-using-label.yaml
+++ b/tests/kuttl/delivery/labels-in-context/00-template-using-label.yaml
@@ -1,0 +1,29 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: carto.run/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: config-template---deliverable-labels-in-context
+spec:
+  configPath: .data.extractedLabel
+  ytt: |
+    #@ load("@ytt:data", "data")
+
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: test-output---deliverable-labels-in-context
+    data:
+      extractedLabel: #@ data.values.labels['carto.run/deliverable-name']

--- a/tests/kuttl/delivery/labels-in-context/01-cluster-delivery.yaml
+++ b/tests/kuttl/delivery/labels-in-context/01-cluster-delivery.yaml
@@ -1,0 +1,39 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: carto.run/v1alpha1
+kind: ClusterSupplyChain
+metadata:
+  name: responsible-ops---deliverable-labels-in-context
+spec:
+  selector:
+    integration-test: "deliverable-labels-in-context"
+  resources:
+    - name: config
+      templateRef:
+        kind: ClusterTemplate
+        name: config-template---deliverable-labels-in-context
+---
+apiVersion: carto.run/v1alpha1
+kind: ClusterDelivery
+metadata:
+  name: responsible-ops---deliverable-labels-in-context
+spec:
+  selector:
+    integration-test: "deliverable-labels-in-context"
+  resources:
+    - name: config
+      templateRef:
+        kind: ClusterTemplate
+        name: config-template---deliverable-labels-in-context

--- a/tests/kuttl/delivery/labels-in-context/02-assert.yaml
+++ b/tests/kuttl/delivery/labels-in-context/02-assert.yaml
@@ -1,0 +1,20 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-output---deliverable-labels-in-context
+data:
+  extractedLabel: petclinic---deliverable-labels-in-context

--- a/tests/kuttl/delivery/labels-in-context/02-deliverable.yaml
+++ b/tests/kuttl/delivery/labels-in-context/02-deliverable.yaml
@@ -1,0 +1,31 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: carto.run/v1alpha1
+kind: Deliverable
+metadata:
+  name: petclinic---deliverable-labels-in-context
+  labels:
+    integration-test: "deliverable-labels-in-context"
+spec:
+  serviceAccountName: my-service-account
+  source:
+    git:
+      url: https://github.com/ekcasey/hello-world-ops
+      ref:
+        branch: prod
+  params:
+    - name: some
+      value: value

--- a/tests/kuttl/supplychain/labels-in-context/00-service-account.yaml
+++ b/tests/kuttl/supplychain/labels-in-context/00-service-account.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-service-account
+secrets:
+  - name: my-service-account-secret
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-service-account-secret
+  annotations:
+    kubernetes.io/service-account.name: my-service-account
+data:
+  token: "ZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNklubFNWM1YxVDNSRldESnZVRE4wTUd0R1EzQmlVVlJOVWtkMFNGb3RYMGh2VUhKYU1FRnVOR0Y0WlRBaWZRLmV5SnBjM01pT2lKcmRXSmxjbTVsZEdWekwzTmxjblpwWTJWaFkyTnZkVzUwSWl3aWEzVmlaWEp1WlhSbGN5NXBieTl6WlhKMmFXTmxZV05qYjNWdWRDOXVZVzFsYzNCaFkyVWlPaUprWldaaGRXeDBJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpXTnlaWFF1Ym1GdFpTSTZJbTE1TFhOaExYUnZhMlZ1TFd4dVkzRndJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5elpYSjJhV05sTFdGalkyOTFiblF1Ym1GdFpTSTZJbTE1TFhOaElpd2lhM1ZpWlhKdVpYUmxjeTVwYnk5elpYSjJhV05sWVdOamIzVnVkQzl6WlhKMmFXTmxMV0ZqWTI5MWJuUXVkV2xrSWpvaU9HSXhNV1V3WldNdFlURTVOeTAwWVdNeUxXRmpORFF0T0RjelpHSmpOVE13TkdKbElpd2ljM1ZpSWpvaWMzbHpkR1Z0T25ObGNuWnBZMlZoWTJOdmRXNTBPbVJsWm1GMWJIUTZiWGt0YzJFaWZRLmplMzRsZ3hpTUtnd0QxUGFhY19UMUZNWHdXWENCZmhjcVhQMEE2VUV2T0F6ek9xWGhpUUdGN2poY3RSeFhmUVFJVEs0Q2tkVmZ0YW5SUjNPRUROTUxVMVBXNXVsV3htVTZTYkMzdmZKT3ozLVJPX3BOVkNmVW8tZURpblN1Wm53bjNzMjNjZU9KM3IzYk04cnBrMHZZZFgyRVlQRGItMnd4cjIzZ1RxUjVxZU5ULW11cS1qYktXVE8wYnRYVl9wVHNjTnFXUkZIVzJBVTVHYVBpbmNWVXg1bXExLXN0SFdOOGtjTG96OF96S2RnUnJGYV92clFjb3NWZzZCRW5MSEt2NW1fVEhaR3AybU8wYmtIV3J1Q2xEUDdLc0tMOFVaZWxvTDN4Y3dQa000VlBBb2V0bDl5MzlvUi1KbWh3RUlIcS1hX3BzaVh5WE9EQU44STcybEZpUSU="
+type: kubernetes.io/service-account-token

--- a/tests/kuttl/supplychain/labels-in-context/00-template-using-label.yaml
+++ b/tests/kuttl/supplychain/labels-in-context/00-template-using-label.yaml
@@ -1,0 +1,29 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: carto.run/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: config-template---workload-labels-in-context
+spec:
+  configPath: .data.extractedLabel
+  ytt: |
+    #@ load("@ytt:data", "data")
+
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: test-output---workload-labels-in-context
+    data:
+      extractedLabel: #@ data.values.labels['carto.run/workload-name']

--- a/tests/kuttl/supplychain/labels-in-context/01-supply-chain.yaml
+++ b/tests/kuttl/supplychain/labels-in-context/01-supply-chain.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: carto.run/v1alpha1
+kind: ClusterSupplyChain
+metadata:
+  name: responsible-ops---workload-labels-in-context
+spec:
+  selector:
+    integration-test: "workload-labels-in-context"
+  resources:
+    - name: config
+      templateRef:
+        kind: ClusterTemplate
+        name: config-template---workload-labels-in-context

--- a/tests/kuttl/supplychain/labels-in-context/02-assert.yaml
+++ b/tests/kuttl/supplychain/labels-in-context/02-assert.yaml
@@ -1,0 +1,20 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-output---workload-labels-in-context
+data:
+  extractedLabel: petclinic---workload-labels-in-context

--- a/tests/kuttl/supplychain/labels-in-context/02-workload.yaml
+++ b/tests/kuttl/supplychain/labels-in-context/02-workload.yaml
@@ -1,0 +1,30 @@
+# Copyright 2021 VMware
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  name: petclinic---workload-labels-in-context
+  labels:
+    integration-test: "workload-labels-in-context"
+spec:
+  serviceAccountName: my-service-account
+  source:
+    git:
+      url: https://github.com/spring-projects/spring-petclinic.git
+      ref:
+        branch: main
+  params:
+    - name: waciuma-com/quality
+      value: omicron


### PR DESCRIPTION
[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Changes proposed by this PR

Introduces labels into the templating context to the v0.5.x line

Similar to what was added into #1128, but adapts for different code at the time.

## Release Note


## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above
- [x] Modified the docs to match changes
