### PR TITLE
Attempt goreleaser fix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,13 +99,10 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
-      # More assembly might be required: Docker logins, GPG, etc. It all depends
-      # on your needs.
-      - uses: goreleaser/goreleaser-action@v2
+      - uses: goreleaser/goreleaser-action@v3
         with:
-          # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TAP }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes proposed by this PR

Attempt to fix broken release for 0.5.x builds:

https://github.com/vmware-tanzu/cartographer/actions/runs/3998349027/jobs/6864309707

In the referenced build, goreleaser fails because it claims `GITHUB_TOKEN` is not set. Looking at the `.github/workflows/release.yaml` file shows that this is obtained from the secret `GITHUB_TAP` which does not exist.

It seems that on main and release/0.6.x lines this line instead references `GITHUB_TOKEN` (see here: https://github.com/vmware-tanzu/cartographer/blob/main/.github/workflows/release.yaml#L108). This PR changes it to be the same on the 0.5.x line.

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above
- [x] Modified the docs to match changes
