### PR TITLE
fix: retract incorrectly released versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,3 +100,10 @@ require (
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
+
+retract (
+	v1.2.0
+	v1.0.1 
+	v0.6.4-yet-another-fake 
+	v0.6.4-still-fake 
+)


### PR DESCRIPTION
There are a few versions that are causing dependabot to create incorrect PRs on projects that depend on cartographer, this PR retracts those versions.

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [ ] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [ ] Filled in the [Release Note](#Release-Note) section above
- [ ] Added any relevant branches to cherry-pick
- [ ] Modified the docs to match changes
