### PR TITLE
Cherry-pick: Deleted stamped immutable objects do not cause error (#1187)

### DIFF
--- a/pkg/controllers/common.go
+++ b/pkg/controllers/common.go
@@ -53,6 +53,10 @@ func immutableEquivalenceTest(realizedResource v1alpha1.ResourceStatus, prevReso
 		return false, fmt.Errorf("get unstructured: %w", err)
 	}
 
+	if prevObj == nil {
+		return false, nil
+	}
+
 	prevLabels := prevObj.GetLabels()
 
 	if lifecycleLabel, ok := prevLabels["carto.run/template-lifecycle"]; !ok || lifecycleLabel == "mutable" {


### PR DESCRIPTION
## Changes proposed by this PR

Cherry-picks #1187 onto 0.6.x release line

## Release Note

Fixes a bug where Cartographer controller may crash if immutable objects stamped are unexpectedly deleted.

## Cherry-pick branches

N/A

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above
- [x] Added any relevant branches to cherry-pick
- [x] Modified the docs to match changes
