### PR TITLE
Remove libgit2 docs

### DIFF
--- a/examples/basic-delivery/README.md
+++ b/examples/basic-delivery/README.md
@@ -57,7 +57,7 @@ To install `cartographer`, refer to [README.md](../../README.md).
 
 4. The controllers of the objects created in the templates referred to in the [ClusterDelivery] object:
 
-- [source-controller](https://fluxcd.io/docs/gitops-toolkit/source-watcher/#install-flux),
+- [source-controller](https://fluxcd.io/docs/gitops-toolkit/source-watcher/#install-flux) v0.33+,
   for providing the ability to find new commits to a git
   repository and making it internally available to other resources
 
@@ -233,7 +233,6 @@ spec:
       interval: 1m0s
       url: $(deliverable.spec.source.git.url)$
       ref: $(deliverable.spec.source.git.ref)$
-      gitImplementation: go-git
       ignore: ""
 ```
 

--- a/examples/basic-delivery/README.md
+++ b/examples/basic-delivery/README.md
@@ -233,7 +233,7 @@ spec:
       interval: 1m0s
       url: $(deliverable.spec.source.git.url)$
       ref: $(deliverable.spec.source.git.ref)$
-      gitImplementation: libgit2
+      gitImplementation: go-git
       ignore: ""
 ```
 

--- a/examples/basic-delivery/app-operator/source-git-repository.yaml
+++ b/examples/basic-delivery/app-operator/source-git-repository.yaml
@@ -29,5 +29,4 @@ spec:
       interval: 1m0s
       url: $(deliverable.spec.source.git.url)$
       ref: $(deliverable.spec.source.git.ref)$
-      gitImplementation: go-git
       ignore: ""

--- a/examples/basic-delivery/app-operator/source-git-repository.yaml
+++ b/examples/basic-delivery/app-operator/source-git-repository.yaml
@@ -29,5 +29,5 @@ spec:
       interval: 1m0s
       url: $(deliverable.spec.source.git.url)$
       ref: $(deliverable.spec.source.git.ref)$
-      gitImplementation: libgit2
+      gitImplementation: go-git
       ignore: ""

--- a/examples/basic-sc/README.md
+++ b/examples/basic-sc/README.md
@@ -498,7 +498,7 @@ spec:
       interval: 1m                       #              object submitted by the
       url: $(workload.source.git.url)$   #                           developers
       ref: $(workload.source.git.ref)$
-      gitImplementation: libgit2
+      gitImplementation: go-git
       ignore: ""
 ```
 

--- a/examples/basic-sc/README.md
+++ b/examples/basic-sc/README.md
@@ -72,7 +72,7 @@ supplychain, forms something powerful.
   for providing an opinionated way of continuously building container
   images using buildpacks
 
-- [source-controller](https://fluxcd.io/docs/gitops-toolkit/source-watcher/#install-flux),
+- [source-controller](https://fluxcd.io/docs/gitops-toolkit/source-watcher/#install-flux) v0.33+,
   for providing the ability to find new commits to a git
   repository and making it internally available to other resources
 
@@ -498,7 +498,6 @@ spec:
       interval: 1m                       #              object submitted by the
       url: $(workload.source.git.url)$   #                           developers
       ref: $(workload.source.git.ref)$
-      gitImplementation: go-git
       ignore: ""
 ```
 

--- a/examples/shared/app-operator/git-source-template.yaml
+++ b/examples/shared/app-operator/git-source-template.yaml
@@ -36,5 +36,4 @@ spec:
       interval: 1m0s
       url: $(workload.spec.source.git.url)$
       ref: $(workload.spec.source.git.ref)$
-      gitImplementation: go-git
       ignore: ""

--- a/examples/shared/app-operator/git-source-template.yaml
+++ b/examples/shared/app-operator/git-source-template.yaml
@@ -36,5 +36,5 @@ spec:
       interval: 1m0s
       url: $(workload.spec.source.git.url)$
       ref: $(workload.spec.source.git.ref)$
-      gitImplementation: libgit2
+      gitImplementation: go-git
       ignore: ""


### PR DESCRIPTION
## Changes proposed by this PR

Remove references to libgit2 in documentation, as the most likely usecase is fluxcd source-controller which no longer supports libgit2.
