### PR TITLE
Validates Deliverable flips to unknown

### DIFF
--- a/tests/integration/delivery/deliverable_reconciler_test.go
+++ b/tests/integration/delivery/deliverable_reconciler_test.go
@@ -924,6 +924,8 @@ var _ = Describe("DeliverableReconciler", func() {
 
 						healthyLastTransitionTime = deliverable.Status.Conditions[3].LastTransitionTime
 
+						time.Sleep(1 * time.Second)
+
 						testToUpdate := getTestObjAtIndex(ctx, testNS, 0, 1)
 						testToUpdate.Status.Conditions = []metav1.Condition{}
 						Expect(c.Status().Update(ctx, testToUpdate)).To(Succeed())


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Cartographer!

Also check the [PR guidelines] if you haven't already!
-->

[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Changes proposed by this PR

<!--
Add the story that is resolved or updated
`closes`/`fixes` or `updates` are valid here 
-->
Validates that a deliverable will flip from Ready==True to Ready==Unknown if a stamped object's health depends on a field which disappears. E.g. Succeeded condition goes from "True" to no longer being on the object.

<!--
Summarize your changes. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->


## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Add CreatorName field in Workload spec

Example notes:

* Operators can label stamped objects with the Workload's creator
* Creators can be contacted when interdepartmental issues arise 

If there are no additional notes necessary you may remove this entire section.
-->
[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## Cherry-pick branches

<!--
List any version lines you think this should be backported to. e.g. "0.5.x"
-->

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [ ] Removed non-atomic or `wip` commits
- ~[ ] Filled in the [Release Note](#Release-Note) section above~
- ~[ ] Added any relevant branches to cherry-pick~
- ~[ ] Modified the docs to match changes~
