### PR TITLE
MissingValueAtPathCondition message is conditioned on object health

### DIFF
--- a/pkg/apis/v1alpha1/conditions.go
+++ b/pkg/apis/v1alpha1/conditions.go
@@ -159,15 +159,14 @@ const (
 // -- RUNNABLE ConditionType - RunTemplateReady ConditionReasons
 
 const (
-	ReadyRunTemplateReason                                    = "Ready"
-	NotFoundRunTemplateReason                                 = "RunTemplateNotFound"
-	StampedObjectRejectedByAPIServerRunTemplateReason         = "StampedObjectRejectedByAPIServer"
-	OutputPathNotSatisfiedRunTemplateReason                   = "OutputPathNotSatisfied"
-	TemplateStampFailureRunTemplateReason                     = "TemplateStampFailure"
-	FailedToListCreatedObjectsReason                          = "FailedToListCreatedObjects"
-	SetOfImmutableStampedObjectsIncludesNoHealthyObjectReason = "SetOfImmutableStampedObjectsIncludesNoHealthyObject"
-	UnknownErrorReason                                        = "UnknownError"
-	ClientBuilderErrorResourcesSubmittedReason                = "ClientBuilderError"
-	SucceededStampedObjectConditionReason                     = "SucceededCondition"
-	UnknownStampedObjectConditionReason                       = "Unknown"
+	ReadyRunTemplateReason                            = "Ready"
+	NotFoundRunTemplateReason                         = "RunTemplateNotFound"
+	StampedObjectRejectedByAPIServerRunTemplateReason = "StampedObjectRejectedByAPIServer"
+	OutputPathNotSatisfiedRunTemplateReason           = "OutputPathNotSatisfied"
+	TemplateStampFailureRunTemplateReason             = "TemplateStampFailure"
+	FailedToListCreatedObjectsReason                  = "FailedToListCreatedObjects"
+	UnknownErrorReason                                = "UnknownError"
+	ClientBuilderErrorResourcesSubmittedReason        = "ClientBuilderError"
+	SucceededStampedObjectConditionReason             = "SucceededCondition"
+	UnknownStampedObjectConditionReason               = "Unknown"
 )

--- a/pkg/conditions/deliverable_conditions.go
+++ b/pkg/conditions/deliverable_conditions.go
@@ -117,7 +117,7 @@ func AddConditionForResourceSubmittedDeliverable(conditionManager *ConditionMana
 		case stamp.DeploymentConditionError:
 			(*conditionManager).AddPositive(DeploymentConditionNotMetCondition(typedErr))
 		case stamp.JsonPathError:
-			(*conditionManager).AddPositive(MissingValueAtPathCondition(isOwner, typedErr.StampedObject, typedErr.JsonPathExpression(), typedErr.GetQualifiedResource()))
+			(*conditionManager).AddPositive(MissingValueAtPathCondition(isOwner, typedErr.StampedObject, typedErr.JsonPathExpression(), typedErr.GetQualifiedResource(), typedErr.Healthy))
 		default:
 			(*conditionManager).AddPositive(UnknownResourceErrorCondition(isOwner, typedErr))
 		}

--- a/pkg/conditions/workload_conditions.go
+++ b/pkg/conditions/workload_conditions.go
@@ -79,10 +79,8 @@ func AddConditionForResourceSubmittedWorkload(conditionManager *ConditionManager
 		(*conditionManager).AddPositive(TemplateRejectedByAPIServerCondition(isOwner, typedErr))
 	case cerrors.ListCreatedObjectsError:
 		(*conditionManager).AddPositive(BlueprintsFailedToListCreatedObjectsCondition(isOwner, typedErr))
-	case cerrors.NoHealthyImmutableObjectsError:
-		(*conditionManager).AddPositive(NoHealthyImmutableObjectsCondition(isOwner, typedErr))
 	case cerrors.RetrieveOutputError:
-		(*conditionManager).AddPositive(MissingValueAtPathCondition(isOwner, typedErr.StampedObject, typedErr.JsonPathExpression(), typedErr.GetQualifiedResource()))
+		(*conditionManager).AddPositive(MissingValueAtPathCondition(isOwner, typedErr.StampedObject, typedErr.JsonPathExpression(), typedErr.GetQualifiedResource(), typedErr.Healthy))
 	case cerrors.ResolveTemplateOptionError:
 		(*conditionManager).AddPositive(ResolveTemplateOptionsErrorCondition(isOwner, typedErr))
 	case cerrors.TemplateOptionsMatchError:

--- a/pkg/controllers/workload_reconciler_test.go
+++ b/pkg/controllers/workload_reconciler_test.go
@@ -850,8 +850,9 @@ var _ = Describe("WorkloadReconciler", func() {
 
 				It("calls the condition manager to report", func() {
 					_, _ = reconciler.Reconcile(ctx, req)
-					Expect(conditionManager.AddPositiveArgsForCall(1)).To(
-						Equal(conditions.MissingValueAtPathCondition(true, stampedObject, "this.wont.find.anything", "mything.thing.io")))
+					var emptyConditionStatus metav1.ConditionStatus
+					Expect(conditionManager.AddPositiveArgsForCall(1)).
+						To(Equal(conditions.MissingValueAtPathCondition(true, stampedObject, "this.wont.find.anything", "mything.thing.io", emptyConditionStatus)))
 				})
 
 				It("does not return an error", func() {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -131,6 +132,7 @@ type RetrieveOutputError struct {
 	BlueprintType     string
 	QualifiedResource string
 	PassThroughInput  string
+	Healthy           metav1.ConditionStatus
 }
 
 func (e RetrieveOutputError) Error() string {
@@ -191,15 +193,6 @@ type NoHealthyImmutableObjectsError struct {
 	ResourceName  string
 	BlueprintName string
 	BlueprintType string
-}
-
-func (e NoHealthyImmutableObjectsError) Error() string {
-	return fmt.Errorf("unable to retrieve outputs for resource [%s] in %s [%s]: %w",
-		e.ResourceName,
-		e.BlueprintType,
-		e.BlueprintName,
-		e.Err,
-	).Error()
 }
 
 func WrapUnhandledError(err error) error {

--- a/pkg/realizer/component.go
+++ b/pkg/realizer/component.go
@@ -206,25 +206,23 @@ func (r *resourceRealizer) doImmutable(ctx context.Context, resource OwnerResour
 
 	var output *templates.Output
 
-	if latestSuccessfulObject == nil {
-		for _, obj := range allRunnableStampedObjects {
-			log.V(logger.DEBUG).Info("failed to retrieve output from any object", "considered", obj)
-		}
-
-		return template, stampedObject, nil, passThrough, templateName, errors.NoHealthyImmutableObjectsError{
-			Err:           fmt.Errorf("failed to find any healthy object in the set of immutable stamped objects"),
-			ResourceName:  resource.Name,
-			BlueprintName: blueprintName,
-			BlueprintType: errors.SupplyChain,
-		}
-	}
-
 	output, err = stampReader.Output(latestSuccessfulObject)
 
 	if err != nil {
-		qualifiedResource, rErr := utils.GetQualifiedResource(mapper, latestSuccessfulObject)
+		var (
+			qualifiedResource string
+			rErr              error
+			objectToReport    *unstructured.Unstructured
+		)
+		if latestSuccessfulObject == nil {
+			objectToReport = stampedObject
+		} else {
+			objectToReport = latestSuccessfulObject
+		}
+
+		qualifiedResource, rErr = utils.GetQualifiedResource(mapper, objectToReport)
 		if rErr != nil {
-			log.Error(err, "failed to retrieve qualified resource name", "object", latestSuccessfulObject)
+			log.Error(err, "failed to retrieve qualified resource name", "object", objectToReport)
 			qualifiedResource = "could not fetch - see the log line for 'failed to retrieve qualified resource name'"
 		}
 

--- a/pkg/realizer/component_test.go
+++ b/pkg/realizer/component_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,10 +37,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/vmware-tanzu/cartographer/pkg/apis/v1alpha1"
+	cerrors "github.com/vmware-tanzu/cartographer/pkg/errors"
 	"github.com/vmware-tanzu/cartographer/pkg/realizer"
 	"github.com/vmware-tanzu/cartographer/pkg/realizer/realizerfakes"
 	"github.com/vmware-tanzu/cartographer/pkg/repository"
 	"github.com/vmware-tanzu/cartographer/pkg/repository/repositoryfakes"
+	"github.com/vmware-tanzu/cartographer/pkg/stamp"
 	"github.com/vmware-tanzu/cartographer/pkg/templates"
 )
 
@@ -264,65 +267,33 @@ var _ = Describe("Resource", func() {
 
 					When("call to list objects succeeds", func() {
 						BeforeEach(func() {
-							stampedObjectWithTime := expectedObject.DeepCopy()
-
-							stampedObjectWithTime.SetCreationTimestamp(metav1.NewTime(time.Unix(1, 0)))
-
-							fakeOwnerRepo.ListUnstructuredReturns([]*unstructured.Unstructured{stampedObjectWithTime}, nil)
+							templateAPI.Spec.TemplateSpec.HealthRule = &v1alpha1.HealthRule{
+								SingleConditionType: "Succeeded",
+							}
 						})
 
-						When("no returned object meets the healthRule", func() {
+						When("a healthy object is returned", func() {
 							BeforeEach(func() {
-								templateAPI.Spec.TemplateSpec.HealthRule = &v1alpha1.HealthRule{
-									SingleConditionType: "Ready",
-								}
-							})
-							It("creates a stamped object, but returns an error and no output", func() {
-								template, returnedStampedObject, out, isPassThrough, templateRefName, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
-								Expect(template).ToNot(BeNil())
-								Expect(isPassThrough).To(BeFalse())
-								Expect(templateRefName).To(Equal("image-template-1"))
-								Expect(returnedStampedObject.Object).To(Equal(expectedObject.Object))
-								Expect(out).To(BeNil())
-
-								Expect(fakeOwnerRepo.EnsureImmutableObjectExistsOnClusterCallCount()).To(Equal(1))
-
-								_, stampedObject, _ := fakeOwnerRepo.EnsureImmutableObjectExistsOnClusterArgsForCall(0)
-
-								Expect(returnedStampedObject).To(Equal(stampedObject))
-
-								metadata := stampedObject.Object["metadata"]
-								metadataValues, ok := metadata.(map[string]interface{})
-								Expect(ok).To(BeTrue())
-								Expect(metadataValues["name"]).To(Equal("example-config-map"))
-								Expect(metadataValues["ownerReferences"]).To(Equal([]interface{}{
-									map[string]interface{}{
-										"apiVersion":         "",
-										"kind":               "",
-										"name":               "",
-										"uid":                "",
-										"controller":         true,
-										"blockOwnerDeletion": true,
+								stampedObjectWithTime := expectedObject.DeepCopy()
+								stampedObjectWithTime.SetCreationTimestamp(metav1.NewTime(time.Unix(1, 0)))
+								stampedObjectWithTime.Object["status"] = map[string]any{
+									"conditions": []map[string]any{
+										{
+											"type":               "Succeeded",
+											"status":             "True",
+											"lastTransitionTime": "2023-08-17T14:30:28Z",
+											"reason":             "",
+											"message":            "",
+										},
 									},
-								}))
-								Expect(stampedObject.Object["data"]).To(Equal(map[string]interface{}{"player_current_lives": "some-url", "some_other_info": "some-revision"}))
-								Expect(metadataValues["labels"]).To(Equal(map[string]interface{}{"expected-labels-from-labeler-placeholder": "labeler"}))
-
-								Expect(err).To(HaveOccurred())
-								Expect(err.Error()).To(ContainSubstring("unable to retrieve outputs for resource [resource-1] in supply chain [supply-chain-name]: failed to find any healthy object in the set of immutable stamped objects"))
-								Expect(reflect.TypeOf(err).String()).To(Equal("errors.NoHealthyImmutableObjectsError"))
-							})
-						})
-
-						When("at least one returned object meets the healthRule", func() {
-							BeforeEach(func() {
-								templateAPI.Spec.TemplateSpec.HealthRule = &v1alpha1.HealthRule{
-									AlwaysHealthy: &runtime.RawExtension{Raw: []byte{}},
 								}
+
+								fakeOwnerRepo.ListUnstructuredReturns([]*unstructured.Unstructured{stampedObjectWithTime}, nil)
 							})
+
 							It("creates a stamped object and returns the outputs and stampedObjects", func() {
 								template, returnedStampedObject, out, isPassThrough, templateRefName, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
-								Expect(err).ToNot(HaveOccurred())
+								Expect(err).NotTo(HaveOccurred())
 								Expect(template).ToNot(BeNil())
 								Expect(isPassThrough).To(BeFalse())
 								Expect(templateRefName).To(Equal("image-template-1"))
@@ -353,6 +324,88 @@ var _ = Describe("Resource", func() {
 
 								Expect(out.Source.Revision).To(Equal("some-revision"))
 								Expect(out.Source.URL).To(Equal("some-url"))
+							})
+						})
+
+						When("no healthy object is returned", func() {
+							BeforeEach(func() {
+								stampedObjectWithTime := expectedObject.DeepCopy()
+								stampedObjectWithTime.SetCreationTimestamp(metav1.NewTime(time.Unix(1, 0)))
+								fakeOwnerRepo.ListUnstructuredReturns([]*unstructured.Unstructured{stampedObjectWithTime}, nil)
+
+								fakeMapper.RESTMappingReturns(&meta.RESTMapping{
+									Resource: schema.GroupVersionResource{
+										Group:    "",
+										Version:  "v1",
+										Resource: "configmap",
+									},
+									GroupVersionKind: schema.GroupVersionKind{
+										Group:   "",
+										Version: "",
+										Kind:    "",
+									},
+									Scope: nil,
+								}, nil)
+							})
+
+							It("returns the expected outputs", func() {
+								template, returnedStampedObject, out, isPassThrough, templateRefName, _ := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+								Expect(template).ToNot(BeNil())
+								Expect(isPassThrough).To(BeFalse())
+								Expect(templateRefName).To(Equal("image-template-1"))
+								Expect(returnedStampedObject.Object).To(Equal(expectedObject.Object))
+
+								Expect(fakeOwnerRepo.EnsureImmutableObjectExistsOnClusterCallCount()).To(Equal(1))
+
+								_, stampedObject, _ := fakeOwnerRepo.EnsureImmutableObjectExistsOnClusterArgsForCall(0)
+
+								Expect(returnedStampedObject).To(Equal(stampedObject))
+
+								metadata := stampedObject.Object["metadata"]
+								metadataValues, ok := metadata.(map[string]interface{})
+								Expect(ok).To(BeTrue())
+								Expect(metadataValues["name"]).To(Equal("example-config-map"))
+								Expect(metadataValues["ownerReferences"]).To(Equal([]interface{}{
+									map[string]interface{}{
+										"apiVersion":         "",
+										"kind":               "",
+										"name":               "",
+										"uid":                "",
+										"controller":         true,
+										"blockOwnerDeletion": true,
+									},
+								}))
+								Expect(stampedObject.Object["data"]).To(Equal(map[string]interface{}{"player_current_lives": "some-url", "some_other_info": "some-revision"}))
+								Expect(metadataValues["labels"]).To(Equal(map[string]interface{}{"expected-labels-from-labeler-placeholder": "labeler"}))
+
+								Expect(out).To(BeNil())
+							})
+
+							It("returns the expected error", func() {
+								_, _, _, _, _, err := r.Do(ctx, resource, blueprintName, outputs, fakeMapper)
+								Expect(err).To(HaveOccurred())
+
+								Expect(err).To(BeAssignableToTypeOf(cerrors.RetrieveOutputError{}))
+
+								Expect(err).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+									"BlueprintName":     Equal("supply-chain-name"),
+									"BlueprintType":     Equal("supply chain"),
+									"QualifiedResource": Equal("configmap"),
+									"PassThroughInput":  Equal(""),
+									"StampedObject":     Equal(&expectedObject),
+									"ResourceName":      Equal("resource-1"),
+									"Healthy": And(
+										BeAssignableToTypeOf(metav1.ConditionUnknown),
+										BeEquivalentTo(""),
+									),
+									"Err": And(
+										BeAssignableToTypeOf(stamp.JsonPathError{}),
+										BeEquivalentTo(stamp.NewJsonPathError(
+											"data.player_current_lives",
+											fmt.Errorf("failed to evaluate path of empty object"),
+										)),
+									),
+								}))
 							})
 						})
 					})

--- a/pkg/stamp/reader.go
+++ b/pkg/stamp/reader.go
@@ -83,7 +83,10 @@ type SourceOutputReader struct {
 
 func (r *SourceOutputReader) Output(stampedObject *unstructured.Unstructured) (*templates.Output, error) {
 	if stampedObject == nil {
-		return nil, fmt.Errorf("failed to evaluate path of empty object")
+		return nil, JsonPathError{
+			Err:        fmt.Errorf("failed to evaluate path of empty object"),
+			expression: r.template.Spec.URLPath,
+		}
 	}
 	// TODO: We don't need a Builder
 	evaluator := eval.EvaluatorBuilder()
@@ -122,7 +125,10 @@ type ConfigOutputReader struct {
 
 func (r *ConfigOutputReader) Output(stampedObject *unstructured.Unstructured) (*templates.Output, error) {
 	if stampedObject == nil {
-		return nil, fmt.Errorf("failed to evaluate path of empty object")
+		return nil, JsonPathError{
+			Err:        fmt.Errorf("failed to evaluate path of empty object"),
+			expression: r.template.Spec.ConfigPath,
+		}
 	}
 	evaluator := eval.EvaluatorBuilder()
 	config, err := evaluator.EvaluateJsonPath(r.template.Spec.ConfigPath, stampedObject.UnstructuredContent())
@@ -151,7 +157,10 @@ type ImageOutputReader struct {
 
 func (r *ImageOutputReader) Output(stampedObject *unstructured.Unstructured) (*templates.Output, error) {
 	if stampedObject == nil {
-		return nil, fmt.Errorf("failed to evaluate path of empty object")
+		return nil, JsonPathError{
+			Err:        fmt.Errorf("failed to evaluate path of empty object"),
+			expression: r.template.Spec.ImagePath,
+		}
 	}
 	evaluator := eval.EvaluatorBuilder()
 	image, err := evaluator.EvaluateJsonPath(r.template.Spec.ImagePath, stampedObject.UnstructuredContent())


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Cartographer!

Also check the [PR guidelines] if you haven't already!
-->

[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Changes proposed by this PR

<!--
Add the story that is resolved or updated
`closes`/`fixes` or `updates` are valid here 
-->
Backport of https://github.com/vmware-tanzu/cartographer/pull/1316

<!--
Summarize your changes. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->


## Release Note
bug fix for statuses on workloads being prematurely marked unhealthy

<!--
Your PR title will be directly included in the release notes when it ships in
the next release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Add CreatorName field in Workload spec

Example notes:

* Operators can label stamped objects with the Workload's creator
* Creators can be contacted when interdepartmental issues arise 

If there are no additional notes necessary you may remove this entire section.
-->
[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## Cherry-pick branches

<!--
List any version lines you think this should be backported to. e.g. "0.5.x"
-->

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above
- [ ] Added any relevant branches to cherry-pick
- ~[ ] Modified the docs to match changes~
