### PR TITLE
Workload status reflects updated supplychain resource order

### DIFF
--- a/pkg/controllers/deliverable_reconciler_test.go
+++ b/pkg/controllers/deliverable_reconciler_test.go
@@ -267,7 +267,7 @@ var _ = Describe("DeliverableReconciler", func() {
 						Name:       "my-image-template",
 						APIVersion: "carto.run/v1alpha1",
 					},
-				}, nil, false)
+				}, 0, nil, false)
 			resourceStatuses.Add(
 				&v1alpha1.RealizedResource{
 					Name: "resource2",
@@ -283,7 +283,7 @@ var _ = Describe("DeliverableReconciler", func() {
 						Name:       "my-config-template",
 						APIVersion: "carto.run/v1alpha1",
 					},
-				}, nil, false)
+				}, 1, nil, false)
 
 			rlzr.RealizeStub = func(ctx context.Context, resourceRealizer realizer.ResourceRealizer, deliveryName string, resources []realizer.OwnerResource, statuses statuses.ResourceStatuses) error {
 				statusesVal := reflect.ValueOf(statuses)
@@ -627,7 +627,7 @@ var _ = Describe("DeliverableReconciler", func() {
 								Name:       "my-image-template",
 								APIVersion: "carto.run/v1alpha1",
 							},
-						}, nil, false,
+						}, 0, nil, false,
 					)
 					resourceStatuses.Add(
 						&v1alpha1.RealizedResource{
@@ -638,7 +638,7 @@ var _ = Describe("DeliverableReconciler", func() {
 								Name:       "my-config-template",
 								APIVersion: "carto.run/v1alpha1",
 							},
-						}, nil, false,
+						}, 1, nil, false,
 					)
 
 					rlzr.RealizeStub = func(ctx context.Context, resourceRealizer realizer.ResourceRealizer, deliveryName string, resources []realizer.OwnerResource, statuses statuses.ResourceStatuses) error {
@@ -1587,7 +1587,7 @@ var _ = Describe("DeliverableReconciler", func() {
 						Kind: "some-template-kind",
 						Name: "some-template-name",
 					},
-				}, nil, false,
+				}, 0, nil, false,
 			)
 			rlzr.RealizeStub = func(ctx context.Context, resourceRealizer realizer.ResourceRealizer, deliveryName string, resources []realizer.OwnerResource, statuses statuses.ResourceStatuses) error {
 				statusesVal := reflect.ValueOf(statuses)

--- a/pkg/controllers/workload_reconciler_test.go
+++ b/pkg/controllers/workload_reconciler_test.go
@@ -267,7 +267,7 @@ var _ = Describe("WorkloadReconciler", func() {
 						Name:       "my-image-template",
 						APIVersion: "carto.run/v1alpha1",
 					},
-				}, nil, false,
+				}, 0, nil, false,
 			)
 			resourceStatuses.Add(
 				&v1alpha1.RealizedResource{
@@ -284,7 +284,7 @@ var _ = Describe("WorkloadReconciler", func() {
 						Name:       "my-config-template",
 						APIVersion: "carto.run/v1alpha1",
 					},
-				}, nil, false,
+				}, 1, nil, false,
 			)
 
 			rlzr.RealizeStub = func(ctx context.Context, resourceRealizer realizer.ResourceRealizer, deliveryName string, resources []realizer.OwnerResource, statuses statuses.ResourceStatuses) error {
@@ -628,7 +628,7 @@ var _ = Describe("WorkloadReconciler", func() {
 								Name:       "my-image-template",
 								APIVersion: "carto.run/v1alpha1",
 							},
-						}, nil, false,
+						}, 0, nil, false,
 					)
 					resourceStatuses.Add(
 						&v1alpha1.RealizedResource{
@@ -639,7 +639,7 @@ var _ = Describe("WorkloadReconciler", func() {
 								Name:       "my-config-template",
 								APIVersion: "carto.run/v1alpha1",
 							},
-						}, nil, false,
+						}, 1, nil, false,
 					)
 
 					rlzr.RealizeStub = func(ctx context.Context, resourceRealizer realizer.ResourceRealizer, deliveryName string, resources []realizer.OwnerResource, statuses statuses.ResourceStatuses) error {
@@ -1377,7 +1377,7 @@ var _ = Describe("WorkloadReconciler", func() {
 						Kind: "some-template-kind",
 						Name: "some-template-name",
 					},
-				}, nil, false,
+				}, 0, nil, false,
 			)
 			rlzr.RealizeStub = func(ctx context.Context, resourceRealizer realizer.ResourceRealizer, deliveryName string, resources []realizer.OwnerResource, statuses statuses.ResourceStatuses) error {
 				statusesVal := reflect.ValueOf(statuses)

--- a/pkg/realizer/realizer.go
+++ b/pkg/realizer/realizer.go
@@ -111,7 +111,7 @@ func (r *realizer) Realize(ctx context.Context, resourceRealizer ResourceRealize
 	outs := NewOutputs()
 	var firstError error
 
-	for _, resource := range ownerResources {
+	for resourceIndex, resource := range ownerResources {
 		log = log.WithValues("resource", resource.Name)
 		ctx = logr.NewContext(ctx, log)
 		template, stampedObject, out, isPassThrough, templateName, err := resourceRealizer.Do(ctx, resource, blueprintName, outs, r.mapper)
@@ -168,7 +168,7 @@ func (r *realizer) Realize(ctx context.Context, resourceRealizer ResourceRealize
 			}
 		}
 
-		resourceStatuses.Add(realizedResource, err, isPassThrough, additionalConditions...)
+		resourceStatuses.Add(realizedResource, resourceIndex, err, isPassThrough, additionalConditions...)
 
 		if slices.Contains(resourceStatuses.ChangedConditionTypes(realizedResource.Name), v1alpha1.ResourceHealthy) {
 			newStatus := metav1.ConditionUnknown

--- a/pkg/realizer/realizer_test.go
+++ b/pkg/realizer/realizer_test.go
@@ -781,7 +781,7 @@ var _ = Describe("Realize", func() {
 				currentStatuses = resourceStatuses.GetCurrent()
 			})
 			It("only creates 1 resource status in currentStatuses", func() {
-				Expect(currentStatuses[0].Name).To(Equal(fmt.Sprintf("resource2")))
+				Expect(currentStatuses[0].Name).To(Equal("resource2"))
 				Expect(len(currentStatuses)).To(Equal(1))
 			})
 		})

--- a/pkg/realizer/realizer_test.go
+++ b/pkg/realizer/realizer_test.go
@@ -518,6 +518,7 @@ var _ = Describe("Realize", func() {
 			previousResources []v1alpha1.ResourceStatus
 			previousTime      metav1.Time
 			supplyChain       *v1alpha1.ClusterSupplyChain
+			resource2         v1alpha1.SupplyChainResource
 		)
 		BeforeEach(func() {
 			previousTime = metav1.NewTime(time.Now())
@@ -593,7 +594,7 @@ var _ = Describe("Realize", func() {
 			resource1 := v1alpha1.SupplyChainResource{
 				Name: "resource1",
 			}
-			resource2 := v1alpha1.SupplyChainResource{
+			resource2 = v1alpha1.SupplyChainResource{
 				Name: "resource2",
 				Sources: []v1alpha1.ResourceReference{
 					{
@@ -692,6 +693,10 @@ var _ = Describe("Realize", func() {
 			var resource3Status v1alpha1.ResourceStatus
 
 			for i := range currentStatuses {
+				Expect(currentStatuses[i].Name).To(Equal(fmt.Sprintf("resource%d", i+1)))
+			}
+
+			for i := range currentStatuses {
 				switch currentStatuses[i].Name {
 				case "resource1":
 					resource1Status = currentStatuses[i]
@@ -741,6 +746,44 @@ var _ = Describe("Realize", func() {
 			Expect(messageFmt).To(Equal("[%s] found healthy status in [%Q] changed to [%s]"))
 			Expect(fmtArgs).To(Equal([]interface{}{"resource1", metav1.ConditionTrue}))
 			Expect(resourceObj).To(Equal(stampedObj1))
+		})
+
+		Context("the supply chain has changed to have fewer resources", func() {
+			var currentStatuses []v1alpha1.ResourceStatus
+			BeforeEach(func() {
+				supplyChain = &v1alpha1.ClusterSupplyChain{
+					ObjectMeta: metav1.ObjectMeta{Name: "greatest-supply-chain"},
+					Spec: v1alpha1.SupplyChainSpec{
+						Resources: []v1alpha1.SupplyChainResource{resource2},
+					},
+				}
+
+				template2 := &v1alpha1.ClusterImageTemplate{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-image-template",
+					},
+				}
+				reader2, err := templates.NewReaderFromAPI(template2)
+				Expect(err).NotTo(HaveOccurred())
+
+				resourceRealizer.DoReturnsOnCall(0, reader2, &unstructured.Unstructured{}, nil, false, resource2.Name, nil)
+
+				oldOutput := &templates.Output{
+					Image: "whatever",
+				}
+				resourceRealizer.DoReturnsOnCall(0, reader2, &unstructured.Unstructured{}, oldOutput, false, "", nil)
+
+				resourceStatuses := statuses.NewResourceStatuses(previousResources, conditions.AddConditionForResourceSubmittedWorkload)
+				err = rlzr.Realize(ctx, resourceRealizer, supplyChain.Name, realizer.MakeSupplychainOwnerResources(supplyChain), resourceStatuses)
+				Expect(err).ToNot(HaveOccurred())
+
+				currentStatuses = resourceStatuses.GetCurrent()
+			})
+			It("only creates 1 resource status in currentStatuses", func() {
+				Expect(currentStatuses[0].Name).To(Equal(fmt.Sprintf("resource2")))
+				Expect(len(currentStatuses)).To(Equal(1))
+			})
 		})
 
 		Context("there is an error realizing resource 1 and resource 2", func() {

--- a/pkg/realizer/statuses/resource_statuses.go
+++ b/pkg/realizer/statuses/resource_statuses.go
@@ -27,7 +27,7 @@ import (
 type ResourceStatuses interface {
 	ChangedConditionTypes(realizedResourceName string) []string
 	GetPreviousResourceStatus(realizedResourceName string) *v1alpha1.ResourceStatus
-	Add(status *v1alpha1.RealizedResource, err error, isPassThrough bool, furtherConditions ...metav1.Condition)
+	Add(status *v1alpha1.RealizedResource, resourceIndex int, err error, isPassThrough bool, furtherConditions ...metav1.Condition)
 	GetCurrent() ResourceStatusList
 	IsChanged() bool
 }
@@ -114,7 +114,7 @@ func (r *resourceStatuses) GetPreviousResourceStatus(realizedResourceName string
 	return nil
 }
 
-func (r *resourceStatuses) Add(realizedResource *v1alpha1.RealizedResource, err error, isPassThrough bool, furtherConditions ...metav1.Condition) {
+func (r *resourceStatuses) Add(realizedResource *v1alpha1.RealizedResource, resourceIndex int, err error, isPassThrough bool, furtherConditions ...metav1.Condition) {
 	name := realizedResource.Name
 
 	var existingStatus *resourceStatus
@@ -129,7 +129,9 @@ func (r *resourceStatuses) Add(realizedResource *v1alpha1.RealizedResource, err 
 		existingStatus = &resourceStatus{
 			name: name,
 		}
-		r.statuses = append(r.statuses, existingStatus)
+		r.statuses = append(r.statuses, &resourceStatus{})
+		copy(r.statuses[resourceIndex+1:], r.statuses[resourceIndex:len(r.statuses)-1])
+		r.statuses[resourceIndex] = existingStatus
 	}
 
 	existingStatus.current = &v1alpha1.ResourceStatus{

--- a/pkg/realizer/statuses/resource_statuses_test.go
+++ b/pkg/realizer/statuses/resource_statuses_test.go
@@ -77,7 +77,7 @@ var _ = Describe("ResourceStatuses", func() {
 					TemplateRef: nil,
 					Inputs:      nil,
 					Outputs:     nil,
-				}, nil, false)
+				}, 0, nil, false)
 			})
 
 			It("the resourceStatuses reports IsChanged is false", func() {
@@ -97,7 +97,7 @@ var _ = Describe("ResourceStatuses", func() {
 					TemplateRef: nil,
 					Inputs:      nil,
 					Outputs:     nil,
-				}, nil, false)
+				}, 1, nil, false)
 				Expect(resourceStatuses.IsChanged()).To(BeTrue())
 			})
 
@@ -108,7 +108,7 @@ var _ = Describe("ResourceStatuses", func() {
 					TemplateRef: nil,
 					Inputs:      nil,
 					Outputs:     nil,
-				}, nil, false)
+				}, 1, nil, false)
 				Expect(resourceStatuses.ChangedConditionTypes("resource2")).To(ConsistOf(v1alpha1.ResourceSubmitted, v1alpha1.ResourceReady))
 			})
 
@@ -119,7 +119,7 @@ var _ = Describe("ResourceStatuses", func() {
 					TemplateRef: nil,
 					Inputs:      nil,
 					Outputs:     nil,
-				}, nil, false, metav1.Condition{
+				}, 1, nil, false, metav1.Condition{
 					Type:   v1alpha1.ResourceHealthy,
 					Status: "Unknown",
 				})
@@ -133,7 +133,7 @@ var _ = Describe("ResourceStatuses", func() {
 					TemplateRef: nil,
 					Inputs:      nil,
 					Outputs:     nil,
-				}, nil, false, metav1.Condition{
+				}, 1, nil, false, metav1.Condition{
 					Type:   v1alpha1.ResourceHealthy,
 					Status: "False",
 				})
@@ -147,7 +147,7 @@ var _ = Describe("ResourceStatuses", func() {
 					TemplateRef: nil,
 					Inputs:      nil,
 					Outputs:     nil,
-				}, nil, false, metav1.Condition{
+				}, 1, nil, false, metav1.Condition{
 					Type:   v1alpha1.ResourceHealthy,
 					Status: "True",
 				})
@@ -168,7 +168,7 @@ var _ = Describe("ResourceStatuses", func() {
 					TemplateRef: nil,
 					Inputs:      nil,
 					Outputs:     nil,
-				}, nil, false)
+				}, 0, nil, false)
 				Expect(resourceStatuses.IsChanged()).To(BeTrue())
 			})
 		})
@@ -181,7 +181,7 @@ var _ = Describe("ResourceStatuses", func() {
 					TemplateRef: nil,
 					Inputs:      nil,
 					Outputs:     nil,
-				}, errors.New("has an error"), false)
+				}, 0, errors.New("has an error"), false)
 				Expect(resourceStatuses.IsChanged()).To(BeTrue())
 			})
 
@@ -192,7 +192,7 @@ var _ = Describe("ResourceStatuses", func() {
 					TemplateRef: nil,
 					Inputs:      nil,
 					Outputs:     nil,
-				}, errors.New("has an error"), false)
+				}, 0, errors.New("has an error"), false)
 				Expect(resourceStatuses.ChangedConditionTypes("resource1")).To(ConsistOf("Ready", "ResourceSubmitted"))
 			})
 		})
@@ -217,7 +217,7 @@ var _ = Describe("ResourceStatuses", func() {
 					TemplateRef: nil,
 					Inputs:      nil,
 					Outputs:     nil,
-				}, nil, false)
+				}, 0, nil, false)
 				Expect(resourceStatuses.IsChanged()).To(BeTrue())
 			})
 		})


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Cartographer!

Also check the [PR guidelines] if you haven't already!
-->

[PR requirements]: https://github.com/vmware-tanzu/cartographer/blob/main/CONTRIBUTING.md#commit-message-and-pr-guidelines

## Workload status reflects supplychain order

Given a source-to-url supply chain

And a workload that is matched on the supply chain

And the workload has run to completion

When I change the supply chain to one that has inserted new resources in the order

Then I see that new resource inserted into the workload's status.resources in the same order that it appears in the supply chain

<!--
Add the story that is resolved or updated
`closes`/`fixes` or `updates` are valid here 
-->

<!--
Summarize your changes. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->


## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Add CreatorName field in Workload spec

Example notes:

* Operators can label stamped objects with the Workload's creator
* Creators can be contacted when interdepartmental issues arise 

If there are no additional notes necessary you may remove this entire section.
-->
[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

Bugfix: When pairing with new supplychain, workload status reflects new supply chain resource order

## Cherry-pick branches
[main](https://github.com/vmware-tanzu/cartographer/pull/1505)
<!--
List any version lines you think this should be backported to. e.g. "0.5.x"
-->

## PR Checklist

Note: Please do not remove items. Mark items as done `[x]` or use ~strikethrough~ if you believe they are not relevant

- [x] Linked to a relevant issue. Eg: `Fixes #123` or `Updates #123`
- [x] Removed non-atomic or `wip` commits
- [x] Filled in the [Release Note](#Release-Note) section above
- [x] Added any relevant branches to cherry-pick
- ~[ ] Modified the docs to match changes~
